### PR TITLE
Support for WTU/WTE files

### DIFF
--- a/skytemple/module/misc_graphics/controller/wte_wtu.glade
+++ b/skytemple/module/misc_graphics/controller/wte_wtu.glade
@@ -2,14 +2,6 @@
 <!-- Generated with glade 3.22.2 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
-  <object class="GtkListStore" id="color_depth_store">
-    <columns>
-      <!-- column-name value -->
-      <column type="gint"/>
-      <!-- column-name explanation -->
-      <column type="gchararray"/>
-    </columns>
-  </object>
   <object class="GtkAdjustment" id="dialog_map_import_adjustment">
     <property name="upper">16</property>
     <property name="value">16</property>
@@ -27,6 +19,14 @@
     <property name="value">1</property>
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
+  </object>
+  <object class="GtkListStore" id="image_type_store">
+    <columns>
+      <!-- column-name value -->
+      <column type="gint"/>
+      <!-- column-name explanation -->
+      <column type="gchararray"/>
+    </columns>
   </object>
   <object class="GtkFileFilter" id="png_filter">
     <patterns>
@@ -186,7 +186,11 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">start</property>
-                <property name="label" translatable="yes">- If no palette is specified, it will be automatically
+                <property name="label" translatable="yes">The palette file is used to assign each color to its correct
+pixel value and to define palette variants for this WTE Image.
+The image file must use the same colors as in
+the first variant defined in the palette file.
+- If no palette is specified, it will be automatically
 generated from the image file provided.
 Note that it is strongly not recommended to do so since 
 there is no way to know which color to use for transparency.
@@ -238,10 +242,10 @@ automatically be considered as a palette-only file.</property>
               </packing>
             </child>
             <child>
-              <object class="GtkComboBox" id="color_depth_setting">
+              <object class="GtkComboBox" id="image_type_setting">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="model">color_depth_store</property>
+                <property name="model">image_type_store</property>
                 <child>
                   <object class="GtkCellRendererText"/>
                   <attributes>
@@ -276,8 +280,7 @@ automatically be considered as a palette-only file.</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">start</property>
-                <property name="label" translatable="yes">If ticked, the WTE file will not contain
-the palette data.
+                <property name="label" translatable="yes">If ticked, the WTE file will not contain the palette data.
 This is for files that use another file's palette data. </property>
               </object>
               <packing>
@@ -606,7 +609,7 @@ Thus, only the palette can be exported from this file, and the palette is displa
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkSpinButton" id="wte_variation">
+                  <object class="GtkSpinButton" id="wte_palette_variant">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="halign">start</property>

--- a/skytemple/module/misc_graphics/controller/wte_wtu.glade
+++ b/skytemple/module/misc_graphics/controller/wte_wtu.glade
@@ -190,10 +190,6 @@
 pixel value and to define palette variants for this WTE Image.
 The image file must use the same colors as in
 the first variant defined in the palette file.
-- If no palette is specified, it will be automatically
-generated from the image file provided.
-Note that it is strongly not recommended to do so since 
-there is no way to know which color to use for transparency.
 - If no image is specified, the WTE file will
 automatically be considered as a palette-only file.</property>
               </object>
@@ -233,7 +229,7 @@ automatically be considered as a palette-only file.</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">start</property>
-                <property name="label" translatable="yes">WTE Image Type</property>
+                <property name="label" translatable="yes">WTE Image Type: </property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -261,7 +257,7 @@ automatically be considered as a palette-only file.</property>
             </child>
             <child>
               <object class="GtkCheckButton" id="chk_discard_palette">
-                <property name="label" translatable="yes">Discard palette</property>
+                <property name="label" translatable="yes">Discard Palette</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">False</property>
@@ -281,7 +277,9 @@ automatically be considered as a palette-only file.</property>
                 <property name="can_focus">False</property>
                 <property name="halign">start</property>
                 <property name="label" translatable="yes">If ticked, the WTE file will not contain the palette data.
-This is for files that use another file's palette data. </property>
+This is for files that use another file's palette data. 
+The palette will be used, however, to assign the correct pixel
+value to each color in the image data.</property>
               </object>
               <packing>
                 <property name="expand">True</property>
@@ -466,9 +464,9 @@ This is for files that use another file's palette data. </property>
                           <object class="GtkLabel">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">Warning: This WTE file doesn't contain any palette data.
+                            <property name="label" translatable="yes">Warning: this WTE file doesn't contain any palette data.
 The palette data used for this file may be in another WTE file.
-A grayscale palette has been generated in order to distinct the different color indices.</property>
+A default grayscale palette has been generated in order to distinct the different color indices.</property>
                             <property name="wrap">True</property>
                           </object>
                           <packing>
@@ -520,7 +518,7 @@ A grayscale palette has been generated in order to distinct the different color 
                           <object class="GtkLabel">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">Warning: This WTE file doesn't contain any image data.
+                            <property name="label" translatable="yes">Warning: this WTE file doesn't contain any image data.
 Thus, only the palette can be exported from this file, and the palette is displayed instead of the image.</property>
                             <property name="wrap">True</property>
                           </object>

--- a/skytemple/module/misc_graphics/controller/wte_wtu.glade
+++ b/skytemple/module/misc_graphics/controller/wte_wtu.glade
@@ -303,13 +303,13 @@ value to each color in the image data.</property>
   </object>
   <object class="GtkListStore" id="wtu_store">
     <columns>
-      <!-- column-name unk0 -->
+      <!-- column-name x -->
       <column type="gchararray"/>
-      <!-- column-name unk1 -->
+      <!-- column-name y -->
       <column type="gchararray"/>
-      <!-- column-name unk2 -->
+      <!-- column-name width -->
       <column type="gchararray"/>
-      <!-- column-name unk3 -->
+      <!-- column-name height -->
       <column type="gchararray"/>
     </columns>
   </object>
@@ -690,43 +690,6 @@ assigned to it.</property>
                 <property name="orientation">vertical</property>
                 <property name="spacing">10</property>
                 <child>
-                  <object class="GtkGrid">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="row_spacing">5</property>
-                    <property name="column_spacing">5</property>
-                    <child>
-                      <object class="GtkLabel">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="halign">end</property>
-                        <property name="label" translatable="yes">UnkC:</property>
-                      </object>
-                      <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkEntry" id="wtu_unkc">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="width_chars">5</property>
-                        <signal name="changed" handler="on_wtu_unkc_changed" swapped="no"/>
-                      </object>
-                      <packing>
-                        <property name="left_attach">1</property>
-                        <property name="top_attach">0</property>
-                      </packing>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
                   <object class="GtkScrolledWindow">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
@@ -736,16 +699,21 @@ assigned to it.</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="model">wtu_store</property>
+                        <signal name="cursor-changed" handler="on_wtu_tree_selection_changed" swapped="no"/>
+                        <signal name="select-all" handler="on_wtu_tree_selection_changed" swapped="no"/>
+                        <signal name="unselect-all" handler="on_wtu_tree_selection_changed" swapped="no"/>
                         <child internal-child="selection">
-                          <object class="GtkTreeSelection"/>
+                          <object class="GtkTreeSelection">
+                            <property name="mode">multiple</property>
+                          </object>
                         </child>
                         <child>
                           <object class="GtkTreeViewColumn">
-                            <property name="title" translatable="yes">Unk0</property>
+                            <property name="title" translatable="yes">x</property>
                             <child>
-                              <object class="GtkCellRendererText" id="wtu_unk0">
+                              <object class="GtkCellRendererText" id="wtu_x">
                                 <property name="editable">True</property>
-                                <signal name="edited" handler="on_wtu_unk0_edited" swapped="no"/>
+                                <signal name="edited" handler="on_wtu_x_edited" swapped="no"/>
                               </object>
                               <attributes>
                                 <attribute name="text">0</attribute>
@@ -755,11 +723,11 @@ assigned to it.</property>
                         </child>
                         <child>
                           <object class="GtkTreeViewColumn">
-                            <property name="title" translatable="yes">Unk1</property>
+                            <property name="title" translatable="yes">y</property>
                             <child>
-                              <object class="GtkCellRendererText" id="wtu_unk1">
+                              <object class="GtkCellRendererText" id="wtu_y">
                                 <property name="editable">True</property>
-                                <signal name="edited" handler="on_wtu_unk1_edited" swapped="no"/>
+                                <signal name="edited" handler="on_wtu_y_edited" swapped="no"/>
                               </object>
                               <attributes>
                                 <attribute name="text">1</attribute>
@@ -769,11 +737,11 @@ assigned to it.</property>
                         </child>
                         <child>
                           <object class="GtkTreeViewColumn">
-                            <property name="title" translatable="yes">Unk2</property>
+                            <property name="title" translatable="yes">width</property>
                             <child>
-                              <object class="GtkCellRendererText" id="wtu_unk2">
+                              <object class="GtkCellRendererText" id="wtu_width">
                                 <property name="editable">True</property>
-                                <signal name="edited" handler="on_wtu_unk2_edited" swapped="no"/>
+                                <signal name="edited" handler="on_wtu_width_edited" swapped="no"/>
                               </object>
                               <attributes>
                                 <attribute name="text">2</attribute>
@@ -783,11 +751,11 @@ assigned to it.</property>
                         </child>
                         <child>
                           <object class="GtkTreeViewColumn">
-                            <property name="title" translatable="yes">Unk3</property>
+                            <property name="title" translatable="yes">height</property>
                             <child>
-                              <object class="GtkCellRendererText" id="wtu_unk3">
+                              <object class="GtkCellRendererText" id="wtu_height">
                                 <property name="editable">True</property>
-                                <signal name="edited" handler="on_wtu_unk3_edited" swapped="no"/>
+                                <signal name="edited" handler="on_wtu_height_edited" swapped="no"/>
                               </object>
                               <attributes>
                                 <attribute name="text">3</attribute>

--- a/skytemple/module/misc_graphics/controller/wte_wtu.glade
+++ b/skytemple/module/misc_graphics/controller/wte_wtu.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.36.0 -->
+<!-- Generated with glade 3.22.2 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkAdjustment" id="dialog_map_import_adjustment">
@@ -19,6 +19,179 @@
     <property name="value">1</property>
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
+  </object>
+  <object class="GtkFileFilter" id="png_filter">
+    <patterns>
+      <pattern>*.png</pattern>
+    </patterns>
+  </object>
+  <object class="GtkDialog" id="dialog_import_settings">
+    <property name="can_focus">False</property>
+    <property name="title" translatable="yes">Import Settings</property>
+    <property name="type_hint">dialog</property>
+    <child type="titlebar">
+      <placeholder/>
+    </child>
+    <child internal-child="vbox">
+      <object class="GtkBox">
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">2</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox">
+            <property name="can_focus">False</property>
+            <property name="layout_style">end</property>
+            <child>
+              <object class="GtkButton" id="btn_cancel">
+                <property name="label">gtk-cancel</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_stock">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="btn_ok">
+                <property name="label">gtk-apply</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_stock">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkGrid">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Image File:</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkFileChooserButton" id="image_path_setting">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="filter">png_filter</property>
+                <property name="title" translatable="yes"/>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Palette:</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkFileChooserButton" id="palette_path_setting">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="filter">png_filter</property>
+                <property name="title" translatable="yes"/>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="orientation">vertical</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">If no palette is specified, 
+it will be automatically generated
+from the image file provided.
+If no image is specified,
+the wte will automatically be considered
+as a palette-only file.</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Import Settings</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkComboBoxText" id="color_depth_setting">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="active">0</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <action-widgets>
+      <action-widget response="-6">btn_cancel</action-widget>
+      <action-widget response="-5">btn_ok</action-widget>
+    </action-widgets>
   </object>
   <object class="GtkListStore" id="wtu_store">
     <columns>
@@ -57,21 +230,6 @@
                 <property name="show_arrow">False</property>
                 <property name="icon_size">2</property>
                 <child>
-                  <object class="GtkToolButton" id="export">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="is_important">True</property>
-                    <property name="label" translatable="yes">Export</property>
-                    <property name="use_underline">True</property>
-                    <property name="icon_name">skytemple-export-symbolic</property>
-                    <signal name="clicked" handler="on_export_clicked" swapped="no"/>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="homogeneous">True</property>
-                  </packing>
-                </child>
-                <child>
                   <object class="GtkToolButton" id="import">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
@@ -80,6 +238,45 @@
                     <property name="use_underline">True</property>
                     <property name="icon_name">skytemple-import-symbolic</property>
                     <signal name="clicked" handler="on_import_clicked" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="homogeneous">True</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkMenuToolButton" id="export">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="is_important">True</property>
+                    <property name="label" translatable="yes">Export</property>
+                    <property name="use_underline">True</property>
+                    <property name="icon_name">skytemple-export-symbolic</property>
+                    <signal name="clicked" handler="on_export_clicked" swapped="no"/>
+                    <child type="menu">
+                      <object class="GtkMenu">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <child>
+                          <object class="GtkMenuItem" id="image_export">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label" translatable="yes">... image</property>
+                            <property name="use_underline">True</property>
+                            <signal name="activate" handler="on_image_export_clicked" swapped="no"/>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkMenuItem" id="palette_export">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label" translatable="yes">... palette</property>
+                            <property name="use_underline">True</property>
+                            <signal name="activate" handler="on_palette_export_clicked" swapped="no"/>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -193,7 +390,7 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="halign">end</property>
-                    <property name="label" translatable="yes">Identifier?:</property>
+                    <property name="label" translatable="yes">Canvas Size: </property>
                   </object>
                   <packing>
                     <property name="left_attach">0</property>
@@ -201,16 +398,86 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkEntry" id="wte_identifier">
+                  <object class="GtkLabel">
                     <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="width_chars">5</property>
-                    <signal name="changed" handler="on_wte_identifier_changed" swapped="no"/>
+                    <property name="can_focus">False</property>
+                    <property name="halign">end</property>
+                    <property name="label" translatable="yes">Width</property>
                   </object>
                   <packing>
                     <property name="left_attach">1</property>
                     <property name="top_attach">0</property>
                   </packing>
+                </child>
+                <child>
+                  <object class="GtkEntry" id="wte_canvas_width">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="width_chars">5</property>
+                    <signal name="changed" handler="on_wte_canvas_width_changed" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="left_attach">2</property>
+                    <property name="top_attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">end</property>
+                    <property name="label" translatable="yes">Height</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">3</property>
+                    <property name="top_attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkEntry" id="wte_canvas_height">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="width_chars">5</property>
+                    <signal name="changed" handler="on_wte_canvas_height_changed" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="left_attach">4</property>
+                    <property name="top_attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">end</property>
+                    <property name="label" translatable="yes">Palette Variation: </property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkSpinButton" id="wte_variation">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="climb_rate">0.0099999997764825821</property>
+                    <property name="numeric">True</property>
+                    <signal name="changed" handler="on_wte_variation_changed" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <placeholder/>
+                </child>
+                <child>
+                  <placeholder/>
+                </child>
+                <child>
+                  <placeholder/>
                 </child>
               </object>
               <packing>
@@ -281,34 +548,10 @@ assigned to it.</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="halign">end</property>
-                        <property name="label" translatable="yes">Identifier?:</property>
-                      </object>
-                      <packing>
-                        <property name="left_attach">0</property>
-                        <property name="top_attach">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkLabel">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="halign">end</property>
                         <property name="label" translatable="yes">UnkC:</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
-                        <property name="top_attach">1</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkEntry" id="wtu_identifier">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="width_chars">5</property>
-                        <signal name="changed" handler="on_wtu_identifier_changed" swapped="no"/>
-                      </object>
-                      <packing>
-                        <property name="left_attach">1</property>
                         <property name="top_attach">0</property>
                       </packing>
                     </child>
@@ -321,7 +564,7 @@ assigned to it.</property>
                       </object>
                       <packing>
                         <property name="left_attach">1</property>
-                        <property name="top_attach">1</property>
+                        <property name="top_attach">0</property>
                       </packing>
                     </child>
                   </object>

--- a/skytemple/module/misc_graphics/controller/wte_wtu.glade
+++ b/skytemple/module/misc_graphics/controller/wte_wtu.glade
@@ -88,11 +88,13 @@
           <object class="GtkGrid">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="margin_bottom">5</property>
             <child>
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Image File:</property>
+                <property name="halign">end</property>
+                <property name="label" translatable="yes">Image File: </property>
               </object>
               <packing>
                 <property name="left_attach">0</property>
@@ -103,6 +105,7 @@
               <object class="GtkFileChooserButton" id="image_path_setting">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="hexpand">True</property>
                 <property name="filter">png_filter</property>
                 <property name="title" translatable="yes"/>
               </object>
@@ -115,7 +118,8 @@
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Palette:</property>
+                <property name="halign">end</property>
+                <property name="label" translatable="yes">Palette: </property>
               </object>
               <packing>
                 <property name="left_attach">0</property>
@@ -126,11 +130,41 @@
               <object class="GtkFileChooserButton" id="palette_path_setting">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="hexpand">True</property>
                 <property name="filter">png_filter</property>
                 <property name="title" translatable="yes"/>
               </object>
               <packing>
                 <property name="left_attach">1</property>
+                <property name="top_attach">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="clear_image_path">
+                <property name="label">gtk-clear</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_stock">True</property>
+                <signal name="clicked" handler="on_clear_image_path_clicked" swapped="no"/>
+              </object>
+              <packing>
+                <property name="left_attach">2</property>
+                <property name="top_attach">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton">
+                <property name="label">gtk-clear</property>
+                <property name="name">clear_palette_path</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_stock">True</property>
+                <signal name="clicked" handler="on_clear_palette_path_clicked" swapped="no"/>
+              </object>
+              <packing>
+                <property name="left_attach">2</property>
                 <property name="top_attach">1</property>
               </packing>
             </child>
@@ -145,17 +179,44 @@
           <object class="GtkBox">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="margin_bottom">10</property>
             <property name="orientation">vertical</property>
             <child>
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">If no palette is specified, 
-it will be automatically generated
-from the image file provided.
-If no image is specified,
-the wte will automatically be considered
-as a palette-only file.</property>
+                <property name="halign">start</property>
+                <property name="label" translatable="yes">- If no palette is specified, it will be automatically
+generated from the image file provided.
+Note that it is strongly not recommended to do so since 
+there is no way to know which color to use for transparency.
+- If no image is specified, the WTE file will
+automatically be considered as a palette-only file.</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="orientation">vertical</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="margin_bottom">5</property>
+                <property name="label" translatable="yes">Import Settings</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -167,7 +228,8 @@ as a palette-only file.</property>
               <object class="GtkLabel">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="label" translatable="yes">Import Settings</property>
+                <property name="halign">start</property>
+                <property name="label" translatable="yes">WTE Image Type</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -191,6 +253,37 @@ as a palette-only file.</property>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
                 <property name="position">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkCheckButton" id="chk_discard_palette">
+                <property name="label" translatable="yes">Discard palette</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">False</property>
+                <property name="halign">start</property>
+                <property name="margin_top">5</property>
+                <property name="draw_indicator">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">3</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="halign">start</property>
+                <property name="label" translatable="yes">If ticked, the WTE file will not contain
+the palette data.
+This is for files that use another file's palette data. </property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">4</property>
               </packing>
             </child>
           </object>
@@ -289,6 +382,14 @@ as a palette-only file.</property>
                             <signal name="activate" handler="on_palette_export_clicked" swapped="no"/>
                           </object>
                         </child>
+                        <child>
+                          <object class="GtkMenuItem" id="all_export">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label" translatable="yes">... all</property>
+                            <signal name="activate" handler="on_all_export_clicked" swapped="no"/>
+                          </object>
+                        </child>
                       </object>
                     </child>
                   </object>
@@ -334,7 +435,7 @@ as a palette-only file.</property>
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkInfoBar" id="info_weird">
+                  <object class="GtkInfoBar" id="info_image_only">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="message_type">warning</property>
@@ -362,7 +463,9 @@ as a palette-only file.</property>
                           <object class="GtkLabel">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">Warning: This WTE file is weird, some of it's properties could not be reliably loaded. Importing a new image may cause it to no longer be readable by the game.</property>
+                            <property name="label" translatable="yes">Warning: This WTE file doesn't contain any palette data.
+The palette data used for this file may be in another WTE file.
+A grayscale palette has been generated in order to distinct the different color indices.</property>
                             <property name="wrap">True</property>
                           </object>
                           <packing>
@@ -385,6 +488,62 @@ as a palette-only file.</property>
                     <property name="position">1</property>
                   </packing>
                 </child>
+                <child>
+                  <object class="GtkInfoBar" id="info_palette_only">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="message_type">warning</property>
+                    <property name="revealed">False</property>
+                    <child internal-child="action_area">
+                      <object class="GtkButtonBox">
+                        <property name="can_focus">False</property>
+                        <property name="spacing">6</property>
+                        <property name="layout_style">end</property>
+                        <child>
+                          <placeholder/>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child internal-child="content_area">
+                      <object class="GtkBox">
+                        <property name="can_focus">False</property>
+                        <property name="spacing">16</property>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label" translatable="yes">Warning: This WTE file doesn't contain any image data.
+Thus, only the palette can be exported from this file, and the palette is displayed instead of the image.</property>
+                            <property name="wrap">True</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
               </object>
               <packing>
                 <property name="expand">True</property>
@@ -404,11 +563,11 @@ as a palette-only file.</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="halign">end</property>
-                    <property name="label" translatable="yes">Canvas Size: </property>
+                    <property name="label" translatable="yes">Palette Variant: </property>
                   </object>
                   <packing>
                     <property name="left_attach">0</property>
-                    <property name="top_attach">0</property>
+                    <property name="top_attach">2</property>
                   </packing>
                 </child>
                 <child>
@@ -416,58 +575,33 @@ as a palette-only file.</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="halign">end</property>
-                    <property name="label" translatable="yes">Width</property>
+                    <property name="label" translatable="yes">Image Size: </property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">end</property>
+                    <property name="label" translatable="yes">WTE Image Type: </property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel" id="lbl_canvas_size">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
                   </object>
                   <packing>
                     <property name="left_attach">1</property>
-                    <property name="top_attach">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkEntry" id="wte_canvas_width">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="width_chars">5</property>
-                    <signal name="changed" handler="on_wte_canvas_width_changed" swapped="no"/>
-                  </object>
-                  <packing>
-                    <property name="left_attach">2</property>
-                    <property name="top_attach">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="halign">end</property>
-                    <property name="label" translatable="yes">Height</property>
-                  </object>
-                  <packing>
-                    <property name="left_attach">3</property>
-                    <property name="top_attach">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkEntry" id="wte_canvas_height">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="width_chars">5</property>
-                    <signal name="changed" handler="on_wte_canvas_height_changed" swapped="no"/>
-                  </object>
-                  <packing>
-                    <property name="left_attach">4</property>
-                    <property name="top_attach">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="halign">end</property>
-                    <property name="label" translatable="yes">Palette Variation: </property>
-                  </object>
-                  <packing>
-                    <property name="left_attach">0</property>
                     <property name="top_attach">1</property>
                   </packing>
                 </child>
@@ -475,29 +609,32 @@ as a palette-only file.</property>
                   <object class="GtkSpinButton" id="wte_variation">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
+                    <property name="halign">start</property>
                     <property name="climb_rate">0.0099999997764825821</property>
                     <property name="numeric">True</property>
                     <signal name="changed" handler="on_wte_variation_changed" swapped="no"/>
                   </object>
                   <packing>
                     <property name="left_attach">1</property>
-                    <property name="top_attach">1</property>
+                    <property name="top_attach">2</property>
                   </packing>
                 </child>
                 <child>
-                  <placeholder/>
-                </child>
-                <child>
-                  <placeholder/>
-                </child>
-                <child>
-                  <placeholder/>
+                  <object class="GtkLabel" id="lbl_image_type">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">0</property>
+                  </packing>
                 </child>
               </object>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">True</property>
-                <property name="position">2</property>
+                <property name="position">4</property>
               </packing>
             </child>
           </object>

--- a/skytemple/module/misc_graphics/controller/wte_wtu.glade
+++ b/skytemple/module/misc_graphics/controller/wte_wtu.glade
@@ -115,31 +115,6 @@
               </packing>
             </child>
             <child>
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">end</property>
-                <property name="label" translatable="yes">Palette: </property>
-              </object>
-              <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkFileChooserButton" id="palette_path_setting">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="hexpand">True</property>
-                <property name="filter">png_filter</property>
-                <property name="title" translatable="yes"/>
-              </object>
-              <packing>
-                <property name="left_attach">1</property>
-                <property name="top_attach">1</property>
-              </packing>
-            </child>
-            <child>
               <object class="GtkButton" id="clear_image_path">
                 <property name="label">gtk-clear</property>
                 <property name="visible">True</property>
@@ -151,21 +126,6 @@
               <packing>
                 <property name="left_attach">2</property>
                 <property name="top_attach">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton">
-                <property name="label">gtk-clear</property>
-                <property name="name">clear_palette_path</property>
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="use_stock">True</property>
-                <signal name="clicked" handler="on_clear_palette_path_clicked" swapped="no"/>
-              </object>
-              <packing>
-                <property name="left_attach">2</property>
-                <property name="top_attach">1</property>
               </packing>
             </child>
           </object>
@@ -186,12 +146,8 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="halign">start</property>
-                <property name="label" translatable="yes">The palette file is used to assign each color to its correct
-pixel value and to define palette variants for this WTE Image.
-The image file must use the same colors as in
-the first variant defined in the palette file.
-If no image is specified, the WTE file will
-automatically be considered as a palette-only file.</property>
+                <property name="label" translatable="yes">The image file must be a color-indexed PNG to be imported
+as a WTE file.</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -277,9 +233,7 @@ automatically be considered as a palette-only file.</property>
                 <property name="can_focus">False</property>
                 <property name="halign">start</property>
                 <property name="label" translatable="yes">If ticked, the WTE file will not contain the palette data.
-This is for files that use another file's palette data. 
-The palette will be used, however, to assign the correct pixel
-value to each color in the image data.</property>
+This is for files that use another file's palette data. </property>
               </object>
               <packing>
                 <property name="expand">True</property>
@@ -353,7 +307,7 @@ value to each color in the image data.</property>
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkMenuToolButton" id="export">
+                  <object class="GtkToolButton" id="export">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="is_important">True</property>
@@ -361,38 +315,6 @@ value to each color in the image data.</property>
                     <property name="use_underline">True</property>
                     <property name="icon_name">skytemple-export-symbolic</property>
                     <signal name="clicked" handler="on_export_clicked" swapped="no"/>
-                    <child type="menu">
-                      <object class="GtkMenu">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <child>
-                          <object class="GtkMenuItem" id="image_export">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">... image</property>
-                            <property name="use_underline">True</property>
-                            <signal name="activate" handler="on_image_export_clicked" swapped="no"/>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="GtkMenuItem" id="palette_export">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">... palette</property>
-                            <property name="use_underline">True</property>
-                            <signal name="activate" handler="on_palette_export_clicked" swapped="no"/>
-                          </object>
-                        </child>
-                        <child>
-                          <object class="GtkMenuItem" id="all_export">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">... image and palette</property>
-                            <signal name="activate" handler="on_all_export_clicked" swapped="no"/>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -519,7 +441,7 @@ A default grayscale palette has been generated in order to distinct the differen
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="label" translatable="yes">Warning: this WTE file doesn't contain any image data.
-Thus, only the palette can be exported from this file, and the palette is displayed instead of the image.</property>
+Thus, the palette is displayed instead of the image.</property>
                             <property name="wrap">True</property>
                           </object>
                           <packing>

--- a/skytemple/module/misc_graphics/controller/wte_wtu.glade
+++ b/skytemple/module/misc_graphics/controller/wte_wtu.glade
@@ -57,7 +57,7 @@
             </child>
             <child>
               <object class="GtkButton" id="btn_ok">
-                <property name="label">gtk-apply</property>
+                <property name="label">gtk-ok</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">True</property>

--- a/skytemple/module/misc_graphics/controller/wte_wtu.glade
+++ b/skytemple/module/misc_graphics/controller/wte_wtu.glade
@@ -190,7 +190,7 @@
 pixel value and to define palette variants for this WTE Image.
 The image file must use the same colors as in
 the first variant defined in the palette file.
-- If no image is specified, the WTE file will
+If no image is specified, the WTE file will
 automatically be considered as a palette-only file.</property>
               </object>
               <packing>
@@ -613,7 +613,7 @@ Thus, only the palette can be exported from this file, and the palette is displa
                     <property name="halign">start</property>
                     <property name="climb_rate">0.0099999997764825821</property>
                     <property name="numeric">True</property>
-                    <signal name="changed" handler="on_wte_variation_changed" swapped="no"/>
+                    <signal name="changed" handler="on_wte_variant_changed" swapped="no"/>
                   </object>
                   <packing>
                     <property name="left_attach">1</property>

--- a/skytemple/module/misc_graphics/controller/wte_wtu.glade
+++ b/skytemple/module/misc_graphics/controller/wte_wtu.glade
@@ -387,7 +387,7 @@ value to each color in the image data.</property>
                           <object class="GtkMenuItem" id="all_export">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">... all</property>
+                            <property name="label" translatable="yes">... image and palette</property>
                             <signal name="activate" handler="on_all_export_clicked" swapped="no"/>
                           </object>
                         </child>

--- a/skytemple/module/misc_graphics/controller/wte_wtu.glade
+++ b/skytemple/module/misc_graphics/controller/wte_wtu.glade
@@ -2,6 +2,14 @@
 <!-- Generated with glade 3.22.2 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
+  <object class="GtkListStore" id="color_depth_store">
+    <columns>
+      <!-- column-name value -->
+      <column type="gint"/>
+      <!-- column-name explanation -->
+      <column type="gchararray"/>
+    </columns>
+  </object>
   <object class="GtkAdjustment" id="dialog_map_import_adjustment">
     <property name="upper">16</property>
     <property name="value">16</property>
@@ -168,10 +176,16 @@ as a palette-only file.</property>
               </packing>
             </child>
             <child>
-              <object class="GtkComboBoxText" id="color_depth_setting">
+              <object class="GtkComboBox" id="color_depth_setting">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="active">0</property>
+                <property name="model">color_depth_store</property>
+                <child>
+                  <object class="GtkCellRendererText"/>
+                  <attributes>
+                    <attribute name="text">1</attribute>
+                  </attributes>
+                </child>
               </object>
               <packing>
                 <property name="expand">False</property>

--- a/skytemple/module/misc_graphics/controller/wte_wtu.py
+++ b/skytemple/module/misc_graphics/controller/wte_wtu.py
@@ -227,7 +227,7 @@ class WteWtuController(AbstractController):
             val = int(self.builder.get_object('wte_variation').get_text())
         except ValueError:
             val = 0
-        self.surface = pil_to_cairo_surface(self.wte.to_pil(val).convert('RGBA'))
+        self.surface = pil_to_cairo_surface(self.wte.to_pil_canvas(val).convert('RGBA'))
         self.builder.get_object('draw').queue_draw()
 
     def on_wte_variation_changed(self, widget):

--- a/skytemple/module/misc_graphics/controller/wte_wtu.py
+++ b/skytemple/module/misc_graphics/controller/wte_wtu.py
@@ -231,7 +231,7 @@ class WteWtuController(AbstractController):
         self.surface = pil_to_cairo_surface(self.wte.to_pil_canvas(val).convert('RGBA'))
         self.builder.get_object('draw').queue_draw()
 
-    def on_wte_variation_changed(self, widget):
+    def on_wte_variant_changed(self, widget):
         try:
             val = int(widget.get_text())
         except ValueError:

--- a/skytemple/module/misc_graphics/controller/wte_wtu.py
+++ b/skytemple/module/misc_graphics/controller/wte_wtu.py
@@ -114,10 +114,8 @@ class WteWtuController(AbstractController):
             "Export image and palette as PNGs in folder...",
             MainController.window(),
             Gtk.FileChooserAction.SELECT_FOLDER,
-            (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL, Gtk.STOCK_SAVE, Gtk.ResponseType.OK)
+            (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL, Gtk.STOCK_OPEN, Gtk.ResponseType.OK)
         )
-
-        add_dialog_png_filter(dialog)
 
         response = dialog.run()
         fn = dialog.get_filename()
@@ -327,7 +325,7 @@ class WteWtuController(AbstractController):
             ctx.set_source_surface(self.surface, 0, 0)
             ctx.get_source().set_filter(cairo.Filter.NEAREST)
             ctx.paint()
-            # Draw rectangles on the WTE image represented by the selected WTU entries
+            # Draw rectangles on the WTE image representing the selected WTU entries
             # Allows multiple selections
             active_rows : List[Gtk.TreePath] = self.builder.get_object('wtu_tree').get_selection().get_selected_rows()[1]
             store: Gtk.ListStore = self.builder.get_object('wtu_store')

--- a/skytemple/module/misc_graphics/controller/wte_wtu.py
+++ b/skytemple/module/misc_graphics/controller/wte_wtu.py
@@ -205,8 +205,12 @@ class WteWtuController(AbstractController):
         self.builder.get_object('wte_palette_variant').set_text(str(0))
         self.builder.get_object('wte_palette_variant').set_increments(1,1)
         self.builder.get_object('wte_palette_variant').set_range(0, self.wte.nb_palette_variants()-1)
-        
-        self.builder.get_object('lbl_canvas_size').set_text(f"{self.wte.width}x{self.wte.height}")
+
+        dimensions : Tuple[int, int] = self.wte.actual_dimensions()
+        if self.wte.has_image():
+            self.builder.get_object('lbl_canvas_size').set_text(f"{self.wte.width}x{self.wte.height} [{dimensions[0]}x{dimensions[1]}]")
+        else:
+            self.builder.get_object('lbl_canvas_size').set_text(f"{self.wte.width}x{self.wte.height} [No image data]")
         self.builder.get_object('lbl_image_type').set_text(self.wte.image_type.explanation)
         
         self.builder.get_object('image_export').set_sensitive(self.wte.has_image())

--- a/skytemple/module/misc_graphics/controller/wte_wtu.py
+++ b/skytemple/module/misc_graphics/controller/wte_wtu.py
@@ -110,15 +110,18 @@ class WteWtuController(AbstractController):
 
     def on_import_clicked(self, *args):
         dialog: Gtk.Dialog = self.builder.get_object('dialog_import_settings')
+        self.builder.get_object('image_path_setting').unselect_all()
+        self.builder.get_object('palette_path_setting').unselect_all()
         dialog.set_attached_to(MainController.window())
         dialog.set_transient_for(MainController.window())
 
         resp = dialog.run()
         dialog.hide()
-        if resp == ResponseType.APPLY:
-            img_fn : Optional[str] = dialog.get_object('image_path_setting').get_filename()
-            pal_fn : Optional[str] = dialog.get_object('palette_path_setting').get_filename()
+        if resp == ResponseType.OK:
+            img_fn : Optional[str] = self.builder.get_object('image_path_setting').get_filename()
+            pal_fn : Optional[str] = self.builder.get_object('palette_path_setting').get_filename()
             img_pil : Optional[Image.Image] = None
+            pal_pil : Optional[Image.Image] = None
             if img_fn!=None:
                 try:
                     img_pil = Image.open(img_fn, 'r')
@@ -130,15 +133,16 @@ class WteWtuController(AbstractController):
                     )
             if pal_fn!=None:
                 try:
-                    img_pil = Image.open(pal_fn, 'r')
+                    pal_pil = Image.open(pal_fn, 'r')
                 except Exception as err:
                     display_error(
                         sys.exc_info(),
                         str(err),
                         "Error importing the palette."
                     )
-            self.wte.from_pil(img_fn, pal_fn, ColorDepth.COLOR_4BPP)
+            self.wte.from_pil(img_pil, pal_pil, ColorDepth.COLOR_4BPP)
             self.module.mark_wte_as_modified(self.item, self.wte, self.wtu)
+            self._init_wte()
             self._reinit_image()
             if self.wtu:
                 self.wtu.image_mode = self.wte.get_mode()


### PR DESCRIPTION
Based on pull request Skytemple/skytemple-files#24.
- Identifier boxes have been removed and replaced by a description of the current image mode, the size and the actual dimensions of the WTE image.
- When importing, you can now choose which image mode to use and if the palette will be included into the file; actual dimensions are computed from the imported image size.
- You can also see palette variants for some WTE files (like frames or dungeons UI).
- Selecting WTU entries shows rectangles representing them on the WTE image.

This pull request and the other one should fix #56.