### PR TITLE
Improving fixed floors and monster spawns types.

### DIFF
--- a/skytemple/module/dungeon/controller/fixed.glade
+++ b/skytemple/module/dungeon/controller/fixed.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.36.0 -->
+<!-- Generated with glade 3.22.2 -->
 <interface>
   <requires lib="gtk+" version="3.20"/>
   <object class="GtkAdjustment" id="dialog_map_import_adjustment">
@@ -1201,66 +1201,6 @@ Tile Properties (ID):</property>
               </packing>
             </child>
             <child>
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">end</property>
-                <property name="label" translatable="yes">Unk4:</property>
-              </object>
-              <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">4</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">end</property>
-                <property name="label" translatable="yes">Unk5:</property>
-              </object>
-              <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">5</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">end</property>
-                <property name="label" translatable="yes">Unk8:</property>
-              </object>
-              <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">6</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">end</property>
-                <property name="label" translatable="yes">Unk9:</property>
-              </object>
-              <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">7</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">end</property>
-                <property name="label" translatable="yes">Unk10:</property>
-              </object>
-              <packing>
-                <property name="left_attach">0</property>
-                <property name="top_attach">8</property>
-              </packing>
-            </child>
-            <child>
               <object class="GtkSwitch" id="settings_orbs">
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
@@ -1269,99 +1209,6 @@ Tile Properties (ID):</property>
               <packing>
                 <property name="left_attach">1</property>
                 <property name="top_attach">3</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkSwitch" id="settings_unk4">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <signal name="notify::active" handler="on_settings_unk4_active_notify" swapped="no"/>
-              </object>
-              <packing>
-                <property name="left_attach">1</property>
-                <property name="top_attach">4</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkSwitch" id="settings_unk5">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <signal name="notify::active" handler="on_settings_unk5_active_notify" swapped="no"/>
-              </object>
-              <packing>
-                <property name="left_attach">1</property>
-                <property name="top_attach">5</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkSwitch" id="settings_unk8">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <signal name="notify::active" handler="on_settings_unk8_active_notify" swapped="no"/>
-              </object>
-              <packing>
-                <property name="left_attach">1</property>
-                <property name="top_attach">6</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkSwitch" id="settings_unk9">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <signal name="notify::active" handler="on_settings_unk9_active_notify" swapped="no"/>
-              </object>
-              <packing>
-                <property name="left_attach">1</property>
-                <property name="top_attach">7</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkSwitch" id="settings_unk10">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <signal name="notify::active" handler="on_settings_unk10_active_notify" swapped="no"/>
-              </object>
-              <packing>
-                <property name="left_attach">1</property>
-                <property name="top_attach">8</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="btn_help_unk8">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="valign">center</property>
-                <child>
-                  <object class="GtkImage">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="icon_name">skytemple-help-about-symbolic</property>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="left_attach">2</property>
-                <property name="top_attach">6</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkButton" id="btn_help_unk9">
-                <property name="visible">True</property>
-                <property name="can_focus">True</property>
-                <property name="receives_default">True</property>
-                <property name="valign">center</property>
-                <child>
-                  <object class="GtkImage">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="icon_name">skytemple-help-about-symbolic</property>
-                  </object>
-                </child>
-              </object>
-              <packing>
-                <property name="left_attach">2</property>
-                <property name="top_attach">7</property>
               </packing>
             </child>
             <child>
@@ -1519,7 +1366,176 @@ if dungeon is cleared:</property>
               </packing>
             </child>
             <child>
-              <placeholder/>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="halign">end</property>
+                <property name="label" translatable="yes">Unk9:</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">8</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="halign">end</property>
+                <property name="label" translatable="yes">Unk8:</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">7</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="halign">end</property>
+                <property name="label" translatable="yes">Unk5:</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">6</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="halign">end</property>
+                <property name="label" translatable="yes">Unk4:</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">5</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="halign">end</property>
+                <property name="label" translatable="yes">Exit floor when defeating all enemies:</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">4</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkSwitch" id="settings_unk9">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <signal name="notify::active" handler="on_settings_unk9_active_notify" swapped="no"/>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">8</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkSwitch" id="settings_unk8">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <signal name="notify::active" handler="on_settings_unk8_active_notify" swapped="no"/>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">7</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkSwitch" id="settings_unk5">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <signal name="notify::active" handler="on_settings_unk5_active_notify" swapped="no"/>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">6</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkSwitch" id="settings_unk4">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <signal name="notify::active" handler="on_settings_unk4_active_notify" swapped="no"/>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">5</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="btn_help_unk9">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="valign">center</property>
+                <child>
+                  <object class="GtkImage">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="icon_name">skytemple-help-about-symbolic</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="left_attach">2</property>
+                <property name="top_attach">8</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkSwitch" id="settings_defeat_enemies">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <signal name="notify::active" handler="on_settings_defeat_enemies_active_notify" swapped="no"/>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">4</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="btn_help_unk8">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="valign">center</property>
+                <child>
+                  <object class="GtkImage">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="icon_name">skytemple-help-about-symbolic</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="left_attach">2</property>
+                <property name="top_attach">7</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="btn_help_defeat_enemies">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="valign">center</property>
+                <child>
+                  <object class="GtkImage">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="icon_name">skytemple-help-about-symbolic</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="left_attach">2</property>
+                <property name="top_attach">4</property>
+              </packing>
             </child>
             <child>
               <placeholder/>

--- a/skytemple/module/dungeon/controller/fixed_rooms.py
+++ b/skytemple/module/dungeon/controller/fixed_rooms.py
@@ -24,6 +24,7 @@ from skytemple.core.string_provider import StringType
 from skytemple.module.dungeon import MAX_ITEM_ID, SPECIAL_ITEMS, SPECIAL_MONSTERS
 from skytemple_files.data.md.model import NUM_ENTITIES
 from skytemple_files.dungeon_data.mappa_bin.trap_list import MappaTrapType
+from skytemple_files.hardcoded.fixed_floor import MonsterSpawnType
 
 if TYPE_CHECKING:
     from skytemple.module.dungeon.module import DungeonModule
@@ -39,9 +40,8 @@ class FixedRoomsController(AbstractController):
             module.get_fixed_floor_entity_lists()
 
         self.enemy_settings_name = [f"{i}: ???" for i in range(0, 256)]
-        self.enemy_settings_name[6] = "6: Enemy"
-        self.enemy_settings_name[9] = "9: Ally"
-        self.enemy_settings_name[10] = "10: Invalid?"
+        for spawn_type in MonsterSpawnType:
+            self.enemy_settings_name[spawn_type.value] = f"{spawn_type.value}: {spawn_type.description}"
 
         self.monster_names = {}
         length = len(self.module.get_monster_md().entries)
@@ -157,7 +157,7 @@ class FixedRoomsController(AbstractController):
                 self.module.desc_fixed_floor_tile(self.lst_tile[entity.tile_id]),
                 self.module.desc_fixed_floor_item(self.lst_item[entity.item_id].item_id),
                 self.module.desc_fixed_floor_monster(
-                    monster.md_idx, monster.enemy_settings, self.monster_names, self.enemy_settings_name
+                    monster.md_idx, monster.enemy_settings.value, self.monster_names, self.enemy_settings_name
                 )
             ])
 
@@ -216,6 +216,6 @@ class FixedRoomsController(AbstractController):
         store: Gtk.ListStore = self.builder.get_object('model_monsters')
         for idx, monster in enumerate(self.lst_monster):
             store.append([
-                str(idx), monster.md_idx, self.monster_names[monster.md_idx], monster.enemy_settings,
-                self.enemy_settings_name[monster.enemy_settings]
+                str(idx), monster.md_idx, self.monster_names[monster.md_idx], monster.enemy_settings.value,
+                self.enemy_settings_name[monster.enemy_settings.value]
             ])

--- a/skytemple/module/dungeon/module.py
+++ b/skytemple/module/dungeon/module.py
@@ -470,7 +470,7 @@ class DungeonModule(AbstractModule):
             BinaryName.OVERLAY_10, lambda binary: HardcodedFixedFloorTables.set_fixed_floor_properties(
                 binary, properties, self.project.get_rom_module().get_static_data()
         ))
-        self.mark_floor_as_modified(floor_id)
+        self.mark_fixed_floor_as_modified(floor_id)
 
     def save_fixed_floor_override(self, floor_id, override_id):
         overrides = self.get_fixed_floor_overrides()
@@ -479,7 +479,7 @@ class DungeonModule(AbstractModule):
             BinaryName.OVERLAY_29, lambda binary: HardcodedFixedFloorTables.set_fixed_floor_overrides(
                 binary, overrides, self.project.get_rom_module().get_static_data()
         ))
-        self.mark_floor_as_modified(floor_id)
+        self.mark_fixed_floor_as_modified(floor_id)
 
     def mark_fixed_floor_as_modified(self, floor_id):
         self.project.mark_as_modified(FIXED_PATH)


### PR DESCRIPTION
Related to Skytemple/skytemple-files#25
- The UI now uses the enumeration from skytemple-files to display the spawn type description.
- I renamed the unknown boolean 10 in fixed floor properties according to the pull request above.
- Some other minor fixes, like the switch for unknown boolean 8 not working because of some typo.