### PR TITLE
 Display one error per portrait when importing via SpriteBot sheets

### DIFF
--- a/skytemple/module/portrait/controller/portrait.py
+++ b/skytemple/module/portrait/controller/portrait.py
@@ -198,8 +198,8 @@ class PortraitController(AbstractController):
         dialog.destroy()
 
         if response == Gtk.ResponseType.OK:
-            try:
-                for subindex, image in SpriteBotSheet.load(fn, self._get_portrait_name):
+            for subindex, image in SpriteBotSheet.load(fn, self._get_portrait_name):
+                try:
                     kao = self.kao.get(self.item_id, subindex)
                     if kao:
                         # Replace
@@ -207,13 +207,14 @@ class PortraitController(AbstractController):
                     else:
                         # New
                         self.kao.set(self.item_id, subindex, KaoImage.new(image))
-            except Exception as err:
-                logger.error(f"Failed importing portraits: {err}", exc_info=err)
-                display_error(
-                    sys.exc_info(),
-                    f'Failed importing portraits:\n{err}',
-                    f"Could not import."
-                )
+                except Exception as err:
+                    name = self._get_portrait_name(subindex)
+                    logger.error(f"Failed importing image '{name}'.", exc_info=err)
+                    display_error(
+                        sys.exc_info(),
+                        f'Failed importing image "{name}":\n{err}',
+                        f"Error for '{name}'."
+                    )
             # Re-render
             self._portrait_provider.reset()
             for draw in self._draws:

--- a/skytemple/module/portrait/controller/portrait.py
+++ b/skytemple/module/portrait/controller/portrait.py
@@ -198,23 +198,31 @@ class PortraitController(AbstractController):
         dialog.destroy()
 
         if response == Gtk.ResponseType.OK:
-            for subindex, image in SpriteBotSheet.load(fn, self._get_portrait_name):
-                try:
-                    kao = self.kao.get(self.item_id, subindex)
-                    if kao:
-                        # Replace
-                        kao.set(image)
-                    else:
-                        # New
-                        self.kao.set(self.item_id, subindex, KaoImage.new(image))
-                except Exception as err:
-                    name = self._get_portrait_name(subindex)
-                    logger.error(f"Failed importing image '{name}'.", exc_info=err)
-                    display_error(
-                        sys.exc_info(),
-                        f'Failed importing image "{name}":\n{err}',
-                        f"Error for '{name}'."
-                    )
+            try:
+                for subindex, image in SpriteBotSheet.load(fn, self._get_portrait_name):
+                    try:
+                        kao = self.kao.get(self.item_id, subindex)
+                        if kao:
+                            # Replace
+                            kao.set(image)
+                        else:
+                            # New
+                            self.kao.set(self.item_id, subindex, KaoImage.new(image))
+                    except Exception as err:
+                        name = self._get_portrait_name(subindex)
+                        logger.error(f"Failed importing image '{name}'.", exc_info=err)
+                        display_error(
+                            sys.exc_info(),
+                            f'Failed importing image "{name}":\n{err}',
+                            f"Error for '{name}'."
+                        )
+            except Exception as err:
+                logger.error(f"Failed importing portraits sheet: {err}", exc_info=err)
+                display_error(
+                    sys.exc_info(),
+                    f'Failed importing portraits sheet:\n{err}',
+                    f"Could not import."
+                )
             # Re-render
             self._portrait_provider.reset()
             for draw in self._draws:


### PR DESCRIPTION
Now, it also displays an error for each portrait that caused an error.
This is important to know which portrait(s) exactly caused the error when importing them (mainly for invalid compressed size, check Skytemple/skytemple-files#32).