### PR TITLE
Minor fixes when marking items as modified

### DIFF
--- a/skytemple/module/dungeon/controller/floor.py
+++ b/skytemple/module/dungeon/controller/floor.py
@@ -158,7 +158,7 @@ class FloorController(AbstractController):
 
     def on_cb_tileset_id_changed(self, w, *args):
         self._update_from_widget(w)
-        self.mark_as_modified()
+        self.mark_as_modified(modified_mappag=True)
 
     def on_cb_music_id_changed(self, w, *args):
         self._update_from_widget(w)
@@ -166,7 +166,7 @@ class FloorController(AbstractController):
 
     def on_cb_fixed_floor_id_changed(self, w, *args):
         self._update_from_widget(w)
-        self.mark_as_modified()
+        self.mark_as_modified(modified_mappag=True)
 
     def on_entry_room_density_changed(self, w, *args):
         self._update_from_widget(w)
@@ -1373,9 +1373,9 @@ class FloorController(AbstractController):
 
         self.mark_as_modified()
 
-    def mark_as_modified(self):
+    def mark_as_modified(self, modified_mappag = False):
         if not self._loading:
-            self.module.mark_floor_as_modified(self.item)
+            self.module.mark_floor_as_modified(self.item, modified_mappag)
 
     def _comboxbox_for_enum(self, names: List[str], enum: Type[Enum]):
         store = Gtk.ListStore(int, str)  # id, name

--- a/skytemple/module/dungeon/module.py
+++ b/skytemple/module/dungeon/module.py
@@ -218,8 +218,11 @@ class DungeonModule(AbstractModule):
     def get_fixed_floor(self, floor_id):
         return self._fixed_floor_data.fixed_floors[floor_id]
 
-    def mark_floor_as_modified(self, item: FloorViewInfo):
-        self.project.mark_as_modified(MAPPA_PATH)
+    def mark_floor_as_modified(self, item: FloorViewInfo, modified_mappag = False):
+        if modified_mappag:
+            self.save_mappa()
+        else:
+            self.project.mark_as_modified(MAPPA_PATH)
         # Mark as modified in tree
         row = self._tree_model[self._dungeon_floor_iters[item.dungeon.dungeon_id][item.floor_id]]
         recursive_up_item_store_mark_as_modified(row)

--- a/skytemple/module/dungeon/module.py
+++ b/skytemple/module/dungeon/module.py
@@ -220,6 +220,8 @@ class DungeonModule(AbstractModule):
 
     def mark_floor_as_modified(self, item: FloorViewInfo, modified_mappag = False):
         if modified_mappag:
+            # This is slow, since it builds the entire mappa_g file from scratch. 
+            # It would be better to only modify the floor attributes changed
             self.save_mappa()
         else:
             self.project.mark_as_modified(MAPPA_PATH)

--- a/skytemple/module/dungeon_graphics/controller/tileset.py
+++ b/skytemple/module/dungeon_graphics/controller/tileset.py
@@ -186,7 +186,7 @@ class TilesetController(AbstractController):
                 self.mark_as_modified()
 
     def mark_as_modified(self):
-        self.module.mark_as_modified(self.item_id)
+        self.module.mark_as_modified(self.item_id, False)
 
     def reload_all(self):
         """Reload all image related things"""


### PR DESCRIPTION
Some fixes about marking items as modified: 
 - the mappa_g data wasn't synced with the mappa data when only the tileset ID or the fixed floor ID was changed
 - the method mark_as_modified from the dungeon_graphics module needed one more argument (is_background) than what was passed by the tileset controller, which caused an error preventing the tileset being marked as modified
