### PR TITLE
Adding primitive support for zmappat file

### DIFF
--- a/skytemple/module/misc_graphics/controller/zmappat.glade
+++ b/skytemple/module/misc_graphics/controller/zmappat.glade
@@ -35,7 +35,7 @@
                 <property name="show_arrow">False</property>
                 <property name="icon_size">2</property>
                 <child>
-                  <object class="GtkToolButton" id="import">
+                  <object class="GtkMenuToolButton" id="import">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="is_important">True</property>
@@ -43,6 +43,28 @@
                     <property name="use_underline">True</property>
                     <property name="icon_name">skytemple-import-symbolic</property>
                     <signal name="clicked" handler="on_import_clicked" swapped="no"/>
+                    <child type="menu">
+                      <object class="GtkMenu">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <child>
+                          <object class="GtkMenuItem" id="import_minimized">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label" translatable="yes">... minimized</property>
+                            <signal name="activate" handler="on_import_minimized_activate" swapped="no"/>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkMenuItem" id="import_full">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label" translatable="yes">... full tileset</property>
+                            <signal name="activate" handler="on_import_full_activate" swapped="no"/>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -50,14 +72,36 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkToolButton" id="export">
+                  <object class="GtkMenuToolButton" id="export">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="is_important">True</property>
                     <property name="label" translatable="yes">Export</property>
                     <property name="use_underline">True</property>
-                    <property name="icon_name">skytemple-export-symbolic</property>
+                    <property name="icon_name">skytemple-import-symbolic</property>
                     <signal name="clicked" handler="on_export_clicked" swapped="no"/>
+                    <child type="menu">
+                      <object class="GtkMenu">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <child>
+                          <object class="GtkMenuItem" id="export_minimized">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label" translatable="yes">... minimized</property>
+                            <signal name="activate" handler="on_export_minimized_activate" swapped="no"/>
+                          </object>
+                        </child>
+                        <child>
+                          <object class="GtkMenuItem" id="export_full">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label" translatable="yes">... full tileset</property>
+                            <signal name="activate" handler="on_export_full_activate" swapped="no"/>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -75,6 +119,7 @@
               <object class="GtkGrid">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="column_homogeneous">True</property>
                 <child>
                   <object class="GtkLabel">
                     <property name="visible">True</property>
@@ -111,31 +156,6 @@
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <child>
-                          <object class="GtkDrawingArea" id="draw_tiles">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="left_attach">0</property>
-                    <property name="top_attach">1</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkScrolledWindow">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="hexpand">True</property>
-                    <property name="vexpand">True</property>
-                    <property name="shadow_type">in</property>
-                    <child>
-                      <object class="GtkViewport">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <child>
                           <object class="GtkDrawingArea" id="draw_masks">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
@@ -149,9 +169,36 @@
                     <property name="top_attach">1</property>
                   </packing>
                 </child>
+                <child>
+                  <object class="GtkScrolledWindow">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="hexpand">True</property>
+                    <property name="vexpand">True</property>
+                    <property name="shadow_type">in</property>
+                    <property name="propagate_natural_width">True</property>
+                    <property name="propagate_natural_height">True</property>
+                    <child>
+                      <object class="GtkViewport">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <child>
+                          <object class="GtkDrawingArea" id="draw_tiles">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">1</property>
+                  </packing>
+                </child>
               </object>
               <packing>
-                <property name="expand">False</property>
+                <property name="expand">True</property>
                 <property name="fill">True</property>
                 <property name="position">1</property>
               </packing>
@@ -225,6 +272,42 @@
                     <property name="left_attach">1</property>
                     <property name="top_attach">1</property>
                   </packing>
+                </child>
+                <child>
+                  <object class="GtkButton" id="minimized_info">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">True</property>
+                    <property name="halign">start</property>
+                    <property name="valign">center</property>
+                    <signal name="clicked" handler="on_minimized_info_clicked" swapped="no"/>
+                    <child>
+                      <object class="GtkImage">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="icon_name">skytemple-help-about-symbolic</property>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">end</property>
+                    <property name="label" translatable="yes">More Info: </property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <placeholder/>
                 </child>
                 <child>
                   <placeholder/>

--- a/skytemple/module/misc_graphics/controller/zmappat.glade
+++ b/skytemple/module/misc_graphics/controller/zmappat.glade
@@ -1,0 +1,258 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.2 -->
+<interface>
+  <requires lib="gtk+" version="3.20"/>
+  <object class="GtkListStore" id="variation_store">
+    <columns>
+      <!-- column-name id -->
+      <column type="guint"/>
+      <!-- column-name description -->
+      <column type="gchararray"/>
+    </columns>
+  </object>
+  <object class="GtkPaned" id="editor">
+    <property name="visible">True</property>
+    <property name="can_focus">True</property>
+    <child>
+      <object class="GtkFrame">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="margin_start">5</property>
+        <property name="margin_end">5</property>
+        <property name="margin_top">5</property>
+        <property name="margin_bottom">5</property>
+        <property name="label_xalign">0</property>
+        <property name="shadow_type">none</property>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="orientation">vertical</property>
+            <child>
+              <object class="GtkToolbar">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="show_arrow">False</property>
+                <property name="icon_size">2</property>
+                <child>
+                  <object class="GtkToolButton" id="import">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="is_important">True</property>
+                    <property name="label" translatable="yes">Import</property>
+                    <property name="use_underline">True</property>
+                    <property name="icon_name">skytemple-import-symbolic</property>
+                    <signal name="clicked" handler="on_import_clicked" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="homogeneous">True</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkToolButton" id="export">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="is_important">True</property>
+                    <property name="label" translatable="yes">Export</property>
+                    <property name="use_underline">True</property>
+                    <property name="icon_name">skytemple-export-symbolic</property>
+                    <signal name="clicked" handler="on_export_clicked" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="homogeneous">True</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkGrid">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="label" translatable="yes">Tiles:</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="label" translatable="yes">Masks:</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkScrolledWindow">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="hexpand">True</property>
+                    <property name="vexpand">True</property>
+                    <property name="shadow_type">in</property>
+                    <child>
+                      <object class="GtkViewport">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <child>
+                          <object class="GtkDrawingArea" id="draw_tiles">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkScrolledWindow">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="hexpand">True</property>
+                    <property name="vexpand">True</property>
+                    <property name="shadow_type">in</property>
+                    <child>
+                      <object class="GtkViewport">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <child>
+                          <object class="GtkDrawingArea" id="draw_masks">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">1</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkGrid">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">end</property>
+                    <property name="label" translatable="yes">Variation: </property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkComboBox" id="zmappat_variation">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="model">variation_store</property>
+                    <signal name="changed" handler="on_zmappat_variation_changed" swapped="no"/>
+                    <child>
+                      <object class="GtkCellRendererText" id="description"/>
+                      <attributes>
+                        <attribute name="text">1</attribute>
+                      </attributes>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">end</property>
+                    <property name="label" translatable="yes">Minimized: </property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">This will show the true form of the file if disabled.</property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">2</property>
+                    <property name="top_attach">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkSwitch" id="switch_minimized">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="halign">start</property>
+                    <property name="active">True</property>
+                    <signal name="state-set" handler="on_switch_minimized_state_set" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <placeholder/>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+          </object>
+        </child>
+        <child type="label">
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="label" translatable="yes">ZMappaT</property>
+          </object>
+        </child>
+      </object>
+      <packing>
+        <property name="resize">True</property>
+        <property name="shrink">False</property>
+      </packing>
+    </child>
+    <child>
+      <placeholder/>
+    </child>
+  </object>
+</interface>

--- a/skytemple/module/misc_graphics/controller/zmappat.py
+++ b/skytemple/module/misc_graphics/controller/zmappat.py
@@ -38,6 +38,9 @@ from skytemple.core.module_controller import AbstractController
 
 logger = logging.getLogger(__name__)
 
+if TYPE_CHECKING:
+    from skytemple.module.misc_graphics.module import MiscGraphicsModule
+
 
 class ZMappaTController(AbstractController):
     def __init__(self, module: 'MiscGraphicsModule', item: str):

--- a/skytemple/module/misc_graphics/controller/zmappat.py
+++ b/skytemple/module/misc_graphics/controller/zmappat.py
@@ -57,8 +57,33 @@ class ZMappaTController(AbstractController):
         return self.builder.get_object('editor')
 
     def on_export_clicked(self, w: Gtk.MenuToolButton):
+        w.get_menu().popup(None, None, None, None, 0, Gtk.get_current_event_time())
+            
+    def on_import_clicked(self, w: Gtk.MenuToolButton):
+        w.get_menu().popup(None, None, None, None, 0, Gtk.get_current_event_time())
+    
+    def on_export_minimized_activate(self, *args):
         dialog = Gtk.FileChooserDialog(
-            "Export zmappat in folder...",
+            "Export zmappat minimized in folder...",
+            MainController.window(),
+            Gtk.FileChooserAction.SELECT_FOLDER,
+            (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL, Gtk.STOCK_SAVE, Gtk.ResponseType.OK)
+        )
+
+        response = dialog.run()
+        fn = dialog.get_filename()
+        dialog.destroy()
+
+        if response == Gtk.ResponseType.OK:
+            for v in ZMappaTVariation:
+                fn_tiles = os.path.join(fn, f'zmappat-{v.filename}-tiles.min.png')
+                fn_masks = os.path.join(fn, f'zmappat-{v.filename}-masks.min.png')
+                surface = self.zmappat.to_pil_tiles_minimized(v).save(fn_tiles, "PNG")
+                mask = self.zmappat.to_pil_masks_minimized(v).save(fn_masks, "PNG")
+
+    def on_export_full_activate(self, *args):
+        dialog = Gtk.FileChooserDialog(
+            "Export full zmappat in folder...",
             MainController.window(),
             Gtk.FileChooserAction.SELECT_FOLDER,
             (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL, Gtk.STOCK_SAVE, Gtk.ResponseType.OK)
@@ -72,13 +97,77 @@ class ZMappaTController(AbstractController):
             for v in ZMappaTVariation:
                 fn_tiles = os.path.join(fn, f'zmappat-{v.filename}-tiles.png')
                 fn_masks = os.path.join(fn, f'zmappat-{v.filename}-masks.png')
-                surface = self.zmappat.to_pil_tiles_minimized(v).save(fn_tiles, "PNG")
-                mask = self.zmappat.to_pil_masks_minimized(v).save(fn_masks, "PNG")
-        pass
-            
-    def on_import_clicked(self, *args):
+                surface = self.zmappat.to_pil_tiles(v).save(fn_tiles, "PNG")
+                mask = self.zmappat.to_pil_masks(v).save(fn_masks, "PNG")
+        
+    def on_import_minimized_activate(self, *args):
+        md = Gtk.MessageDialog(
+            MainController.window(),
+            Gtk.DialogFlags.DESTROY_WITH_PARENT, Gtk.MessageType.INFO,
+            Gtk.ButtonsType.OK,
+            f"To import, select a folder containing all the image files that were created when exporting the minimized version.",
+            title="Import Minimized Version"
+        )
+        md.run()
+        md.destroy()
         dialog = Gtk.FileChooserDialog(
-            "Import zmappat from folder...",
+            "Import zmappat minimized from folder...",
+            MainController.window(),
+            Gtk.FileChooserAction.SELECT_FOLDER,
+            (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL, Gtk.STOCK_OPEN, Gtk.ResponseType.OK)
+        )
+
+        response = dialog.run()
+        fn = dialog.get_filename()
+        dialog.destroy()
+
+        if response == Gtk.ResponseType.OK:
+            try:
+                imgs = [None]*ZMAPPAT_NB_VARIATIONS
+                masks = [None]*ZMAPPAT_NB_VARIATIONS
+                for v in ZMappaTVariation:
+                    fn_tiles = os.path.join(fn, f'zmappat-{v.filename}-tiles.min.png')
+                    fn_masks = os.path.join(fn, f'zmappat-{v.filename}-masks.min.png')
+                    imgs[v.value] = Image.open(fn_tiles, 'r')
+                    masks[v.value] = Image.open(fn_masks, 'r')
+                self.zmappat.from_pil_minimized(imgs, masks)
+                self.module.mark_zmappat_as_modified(self.zmappat, self.filename)
+            except Exception as err:
+                display_error(
+                    sys.exc_info(),
+                    str(err),
+                    "Error importing minimized zmappat."
+                )
+            self._reinit_image()
+        
+    def on_minimized_info_clicked(self, *args):
+        md = Gtk.MessageDialog(
+            MainController.window(),
+            Gtk.DialogFlags.DESTROY_WITH_PARENT, Gtk.MessageType.INFO,
+            Gtk.ButtonsType.OK,
+            f"The game uses 4x4 'mini-tiles' tiles to render the map.\n"
+            f"However, as the system only uses 8x8 tiles, the game render each 8x8 tile by applying 4 mini-tiles with their respective masks.\n"
+            f"To do this, all mini-tiles have been duplicated to cover the 4 possibilites for placing the mini-tile in 8x8 tiles (top left, top right, bottom left, bottom right).\n"
+            f"The mask is then used to apply the mini-tile only on the correct part of the resulting 8x8 tile.\n"
+            f"The minimized version reduces the tileset to only 4x4 mini-tiles and handles the duplication when importing.\n"
+            f"But remember that the full tileset allows more exploits as you can render tiles differently depending on where they are placed.",
+            title="Minimized Version Info"
+        )
+        md.run()
+        md.destroy()
+        
+    def on_import_full_activate(self, *args):
+        md = Gtk.MessageDialog(
+            MainController.window(),
+            Gtk.DialogFlags.DESTROY_WITH_PARENT, Gtk.MessageType.INFO,
+            Gtk.ButtonsType.OK,
+            f"To import, select a folder containing all the image files that were created when exporting the full tileset.",
+            title="Import Full Tileset"
+        )
+        md.run()
+        md.destroy()
+        dialog = Gtk.FileChooserDialog(
+            "Import full zmappat from folder...",
             MainController.window(),
             Gtk.FileChooserAction.SELECT_FOLDER,
             (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL, Gtk.STOCK_OPEN, Gtk.ResponseType.OK)
@@ -97,13 +186,13 @@ class ZMappaTController(AbstractController):
                     fn_masks = os.path.join(fn, f'zmappat-{v.filename}-masks.png')
                     imgs[v.value] = Image.open(fn_tiles, 'r')
                     masks[v.value] = Image.open(fn_masks, 'r')
-                self.zmappat.from_pil_minimized(imgs, masks)
+                self.zmappat.from_pil(imgs, masks)
                 self.module.mark_zmappat_as_modified(self.zmappat, self.filename)
             except Exception as err:
                 display_error(
                     sys.exc_info(),
                     str(err),
-                    "Error importing zmappat."
+                    "Error importing full zmappat."
                 )
             self._reinit_image()
             
@@ -149,6 +238,7 @@ class ZMappaTController(AbstractController):
     
     def draw_tiles(self, wdg, ctx: cairo.Context, *args):
         if self.surface:
+            wdg.set_size_request(self.surface.get_width(), self.surface.get_height())
             ctx.fill()
             ctx.set_source_surface(self.surface, 0, 0)
             ctx.get_source().set_filter(cairo.Filter.NEAREST)
@@ -156,6 +246,7 @@ class ZMappaTController(AbstractController):
         return True
     def draw_masks(self, wdg, ctx: cairo.Context, *args):
         if self.mask:
+            wdg.set_size_request(self.mask.get_width(), self.mask.get_height())
             ctx.fill()
             ctx.set_source_surface(self.mask, 0, 0)
             ctx.get_source().set_filter(cairo.Filter.NEAREST)

--- a/skytemple/module/misc_graphics/controller/zmappat.py
+++ b/skytemple/module/misc_graphics/controller/zmappat.py
@@ -1,0 +1,163 @@
+#  Copyright 2020 Parakoopa
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+import logging
+import os
+import sys
+from typing import TYPE_CHECKING, Optional
+
+import cairo
+
+from skytemple.core.error_handler import display_error
+from skytemple_files.graphics.zmappat.model import ZMappaT, ZMappaTVariation
+from skytemple_files.graphics.zmappat import *
+
+try:
+    from PIL import Image
+except:
+    from pil import Image
+from gi.repository import Gtk
+from gi.repository.Gtk import ResponseType
+
+from skytemple.controller.main import MainController
+from skytemple.core.img_utils import pil_to_cairo_surface
+from skytemple.core.module_controller import AbstractController
+
+logger = logging.getLogger(__name__)
+
+
+class ZMappaTController(AbstractController):
+    def __init__(self, module: 'MiscGraphicsModule', item: str):
+        self.module = module
+        self.filename = item
+        self.zmappat: ZMappaT = self.module.get_dungeon_bin_file(self.filename)
+
+        self.builder = None
+
+    def get_view(self) -> Gtk.Widget:
+        self.builder = self._get_builder(__file__, 'zmappat.glade')
+        self._init_zmappat()
+        self._reinit_image()
+        self.builder.connect_signals(self)
+        self.builder.get_object('draw_tiles').connect('draw', self.draw_tiles)
+        self.builder.get_object('draw_masks').connect('draw', self.draw_masks)
+        return self.builder.get_object('editor')
+
+    def on_export_clicked(self, w: Gtk.MenuToolButton):
+        dialog = Gtk.FileChooserDialog(
+            "Export zmappat in folder...",
+            MainController.window(),
+            Gtk.FileChooserAction.SELECT_FOLDER,
+            (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL, Gtk.STOCK_SAVE, Gtk.ResponseType.OK)
+        )
+
+        response = dialog.run()
+        fn = dialog.get_filename()
+        dialog.destroy()
+
+        if response == Gtk.ResponseType.OK:
+            for v in ZMappaTVariation:
+                fn_tiles = os.path.join(fn, f'zmappat-{v.filename}-tiles.png')
+                fn_masks = os.path.join(fn, f'zmappat-{v.filename}-masks.png')
+                surface = self.zmappat.to_pil_tiles_minimized(v).save(fn_tiles, "PNG")
+                mask = self.zmappat.to_pil_masks_minimized(v).save(fn_masks, "PNG")
+        pass
+            
+    def on_import_clicked(self, *args):
+        dialog = Gtk.FileChooserDialog(
+            "Import zmappat from folder...",
+            MainController.window(),
+            Gtk.FileChooserAction.SELECT_FOLDER,
+            (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL, Gtk.STOCK_OPEN, Gtk.ResponseType.OK)
+        )
+
+        response = dialog.run()
+        fn = dialog.get_filename()
+        dialog.destroy()
+
+        if response == Gtk.ResponseType.OK:
+            try:
+                imgs = [None]*ZMAPPAT_NB_VARIATIONS
+                masks = [None]*ZMAPPAT_NB_VARIATIONS
+                for v in ZMappaTVariation:
+                    fn_tiles = os.path.join(fn, f'zmappat-{v.filename}-tiles.png')
+                    fn_masks = os.path.join(fn, f'zmappat-{v.filename}-masks.png')
+                    imgs[v.value] = Image.open(fn_tiles, 'r')
+                    masks[v.value] = Image.open(fn_masks, 'r')
+                self.zmappat.from_pil_minimized(imgs, masks)
+                self.module.mark_zmappat_as_modified(self.zmappat, self.filename)
+            except Exception as err:
+                display_error(
+                    sys.exc_info(),
+                    str(err),
+                    "Error importing zmappat."
+                )
+            self._reinit_image()
+            
+    def _init_zmappat(self):
+        # Init available variations
+        cb_store: Gtk.ListStore = self.builder.get_object('variation_store')
+        cb: Gtk.ComboBoxText = self.builder.get_object('zmappat_variation')
+        self._fill_available_zmappat_variations_into_store(cb_store)
+        
+        cb.set_active(0)
+        
+    def _reinit_image(self):
+        cb_store: Gtk.ListStore = self.builder.get_object('variation_store')
+        cb: Gtk.ComboBoxText = self.builder.get_object('zmappat_variation')
+        v : int = cb_store[cb.get_active_iter()][0]
+        if self.builder.get_object('switch_minimized').get_active():
+            surface = self.zmappat.to_pil_tiles_minimized(ZMappaTVariation(v))
+            mask = self.zmappat.to_pil_masks_minimized(ZMappaTVariation(v))
+        else:
+            surface = self.zmappat.to_pil_tiles(ZMappaTVariation(v))
+            mask = self.zmappat.to_pil_masks(ZMappaTVariation(v))
+        surface = surface.resize((surface.width*4, surface.height*4))
+        self.surface = pil_to_cairo_surface(surface.convert('RGBA'))
+        mask = mask.resize((mask.width*4, mask.height*4))
+        self.mask = pil_to_cairo_surface(mask.convert('RGBA'))
+        self.builder.get_object('draw_tiles').queue_draw()
+        self.builder.get_object('draw_masks').queue_draw()
+
+    def on_switch_minimized_state_set(self, *args):
+        self._reinit_image()
+        
+    def on_zmappat_variation_changed(self, widget):
+        self._reinit_image()
+    
+    def _fill_available_zmappat_variations_into_store(self, cb_store):
+        variations = [
+            v for v in ZMappaTVariation
+        ]
+        # Init combobox
+        cb_store.clear()
+        for v in variations:
+            cb_store.append([v.value, v.description])
+    
+    def draw_tiles(self, wdg, ctx: cairo.Context, *args):
+        if self.surface:
+            ctx.fill()
+            ctx.set_source_surface(self.surface, 0, 0)
+            ctx.get_source().set_filter(cairo.Filter.NEAREST)
+            ctx.paint()
+        return True
+    def draw_masks(self, wdg, ctx: cairo.Context, *args):
+        if self.mask:
+            ctx.fill()
+            ctx.set_source_surface(self.mask, 0, 0)
+            ctx.get_source().set_filter(cairo.Filter.NEAREST)
+            ctx.paint()
+        return True

--- a/skytemple/module/misc_graphics/module.py
+++ b/skytemple/module/misc_graphics/module.py
@@ -23,15 +23,18 @@ from skytemple.core.rom_project import RomProject
 from skytemple.core.ui_utils import recursive_generate_item_store_row_label, recursive_up_item_store_mark_as_modified
 from skytemple.module.misc_graphics.controller.w16 import W16Controller
 from skytemple.module.misc_graphics.controller.wte_wtu import WteWtuController
+from skytemple.module.misc_graphics.controller.zmappat import ZMappaTController
 from skytemple.module.misc_graphics.controller.main import MainController, MISC_GRAPHICS
 from skytemple_files.common.types.file_types import FileType
 from skytemple_files.container.dungeon_bin.model import DungeonBinPack
 from skytemple_files.graphics.wte.model import Wte
 from skytemple_files.graphics.wtu.model import Wtu
+from skytemple_files.graphics.zmappat.model import ZMappaT
 
 W16_FILE_EXT = 'w16'
 WTE_FILE_EXT = 'wte'
 WTU_FILE_EXT = 'wtu'
+ZMAPPAT_FILE_EXT = 'zmappat'
 DUNGEON_BIN_PATH = 'DUNGEON/dungeon.bin'
 
 
@@ -60,6 +63,7 @@ class MiscGraphicsModule(AbstractModule):
         self.dungeon_bin: Optional[DungeonBinPack] = None
         self.list_of_wtes_dungeon_bin = None
         self.list_of_wtus_dungeon_bin = None
+        self.list_of_zmappats_dungeon_bin = None
 
         self._tree_model = None
         self._tree_level_iter = {}
@@ -72,6 +76,7 @@ class MiscGraphicsModule(AbstractModule):
         )
         self.list_of_wtes_dungeon_bin = self.dungeon_bin.get_files_with_ext(WTE_FILE_EXT)
         self.list_of_wtus_dungeon_bin = self.dungeon_bin.get_files_with_ext(WTU_FILE_EXT)
+        self.list_of_zmappats_dungeon_bin = self.dungeon_bin.get_files_with_ext(ZMAPPAT_FILE_EXT)
 
         root = item_store.append(root_node, [
             'skytemple-e-graphics-symbolic', MISC_GRAPHICS, self, MainController, 0, False, '', True
@@ -113,6 +118,12 @@ class MiscGraphicsModule(AbstractModule):
                     name, wtu_name, True
                 ), False, '', True
             ])
+            
+        # zmappat at the end:
+        for i, name in enumerate(self.list_of_zmappats_dungeon_bin):
+            self._tree_level_dungeon_iter[name] = item_store.append(root, [
+                'skytemple-e-graphics-symbolic', 'dungeon.bin:' + name, self,  ZMappaTController, name, False, '', True
+            ])
 
         recursive_generate_item_store_row_label(self._tree_model[root])
 
@@ -137,6 +148,13 @@ class MiscGraphicsModule(AbstractModule):
     def get_dungeon_bin_file(self, fn):
         return self.dungeon_bin.get(fn)
 
+    def mark_zmappat_as_modified(self, zmappat, fn):
+        self.dungeon_bin.set(fn, zmappat)
+        self.project.mark_as_modified(DUNGEON_BIN_PATH)
+        # Mark as modified in tree
+        row = self._tree_model[self._tree_level_dungeon_iter[fn]]
+        recursive_up_item_store_mark_as_modified(row)
+        
     def mark_wte_as_modified(self, item: WteOpenSpec, wte, wtu):
         if item.in_dungeon_bin:
             self.dungeon_bin.set(item.wte_filename, wte)


### PR DESCRIPTION
See Skytemple/skytemple-files#37.

- Support for viewing zmappat files (under "Misc. Graphics" section).
- UI Support for exporting zmappat data to image files.
- UI Support for importing zmappat data from image files.
- Some explanations about how this file works.

Uses the pull request mentioned above to work.