### PR TITLE
Add packaging for Mac OS

### DIFF
--- a/.github/workflows/build-mac.yml
+++ b/.github/workflows/build-mac.yml
@@ -1,0 +1,57 @@
+name: Mac package
+
+on: [push, pull_request]
+
+jobs:
+  package:
+    runs-on: macos-10.15
+    name: Build and package for Mac OS
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Install and package
+        run: |
+          /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)" # install Homebrew
+          brew install enchant # This installs Python 3.9 for some reason, which we don't want
+          brew uninstall --ignore-dependencies python@3.9
+          brew install git pygobject3 gtk+3 python@3.8 gtksourceview3 adwaita-icon-theme sdl cmake
+          PATH=/usr/local/opt/python@3.8/bin:/usr/local/bin:$PATH
+
+          # Install armips
+          git clone --recursive https://github.com/Kingcom/armips.git
+          mkdir armips/build && cd armips/build
+          cmake -DCMAKE_BUILD_TYPE=Release ..
+          cmake --build .
+          cd - # Go back to the SkyTemple directory
+          cp armips/build/armips ./installer/armips
+
+          # Install skytemple-eventserver to have a compatible version that satifies the requirements.txt
+          git clone https://github.com/SkyTemple/skytemple-eventserver.git
+          pip3 install -r ./skytemple-eventserver/requirements.txt
+          pip3 install ./skytemple-eventserver
+
+          # Install other dependencies and SkyTemple itself
+          pip3 install py-desmume skytemple-rust pyinstaller
+          pip3 install -r requirements-mac.txt
+          pip3 install .
+
+          # Install the McMojave theme
+          cd installer
+          curl https://cdn.discordapp.com/attachments/712341699292037121/784474569884303380/McMojave.zip -o McMojave.zip
+          unzip McMojave.zip > /dev/null
+
+          pip3 install pyinstaller
+
+          # Package
+          current_version=${GITHUB_REF##*/} # https://github.community/t/how-to-get-just-the-tag-name/16241
+          ./build-mac.sh $current_version
+
+          # Creating a zip makes the artifact upload much faster since there are so many files
+          zip -r skytemple-mac.zip dist/SkyTemple.app > /dev/null
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: skytemple-mac-app
+          path: |
+            installer/skytemple-mac.zip

--- a/.gitignore
+++ b/.gitignore
@@ -31,7 +31,6 @@ MANIFEST
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
 *.manifest
-*.spec
 
 # Installer logs
 pip-log.txt

--- a/installer/build-mac.sh
+++ b/installer/build-mac.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+# Call with build-mac.sh [version number]
+# The version from the current pip install of SkyTemple is used if no version number is set.
+set -e
+
+generate_version_file() {
+  location=$(pip3 show $1 | grep Location | cut -d":" -f 2 | cut -c2-)
+  pip3 show $1 | grep Version | cut -d":" -f 2 | cut -c2- > $location/$1/VERSION
+}
+
+# The VERSION files for a few dependencies are missing for some reason, so generate them from 'pip show' commands
+generate_version_file cssselect2
+generate_version_file tinycss2
+generate_version_file cairosvg
+
+# Create the icon
+# https://www.codingforentrepreneurs.com/blog/create-icns-icons-for-macos-apps
+mkdir skytemple.iconset
+icons_path=../skytemple/data/icons/hicolor
+cp $icons_path/16x16/apps/skytemple.png skytemple.iconset/icon_16x16.png
+cp $icons_path/32x32/apps/skytemple.png skytemple.iconset/icon_16x16@2x.png
+cp $icons_path/32x32/apps/skytemple.png skytemple.iconset/icon_32x32.png
+cp $icons_path/64x64/apps/skytemple.png skytemple.iconset/icon_32x32@2x.png
+cp $icons_path/128x128/apps/skytemple.png skytemple.iconset/icon_128x128.png
+cp $icons_path/256x256/apps/skytemple.png skytemple.iconset/icon_128x128@2x.png
+cp $icons_path/256x256/apps/skytemple.png skytemple.iconset/icon_256x256.png
+cp $icons_path/512x512/apps/skytemple.png skytemple.iconset/icon_256x256@2x.png
+cp $icons_path/512x512/apps/skytemple.png skytemple.iconset/icon_512x512.png
+
+iconutil -c icns skytemple.iconset
+rm -rf skytemple.iconset
+
+# Build the app
+pyinstaller skytemple-mac.spec --noconfirm
+
+rm skytemple.icns
+
+# Since the library search path for the app is wrong, execute a shell script that sets is correctly
+# and launches the app instead of launching run_skytemple directly
+appdir=dist/SkyTemple.app/Contents/MacOS
+
+# Change "run_skytemple" to "pre_run_skytemple" in the launcher info to launch the shell script instead of the app
+sed -i '' 's/run_skytemple/pre_run_skytemple/' dist/SkyTemple.app/Contents/Info.plist
+
+# Create a shell script that sets LD_LIBRARY_PATH and launches SkyTemple
+printf '#!/bin/sh\nLD_LIBRARY_PATH=$(dirname $0) $(dirname $0)/run_skytemple\n' > $appdir/pre_run_skytemple
+chmod +x $appdir/pre_run_skytemple
+
+# Write the version number to files that are read at runtime
+version=$1 || $(python3 -c "import pkg_resources; print(pkg_resources.get_distribution(\"skytemple\").version)")
+
+echo $version > $appdir/VERSION
+echo $version > $appdir/data/VERSION

--- a/installer/skytemple-mac.spec
+++ b/installer/skytemple-mac.spec
@@ -1,0 +1,92 @@
+# -*- mode: python ; coding: utf-8 -*-
+import os
+import sys
+import shutil
+import pkg_resources
+from pathlib import PurePosixPath, Path
+
+pkg_path = os.path.abspath(os.path.join('..', 'skytemple'))
+site_packages = next(p for p in sys.path if 'site-packages' in p)
+
+additional_datas = [
+    (os.path.join(pkg_path, 'data'), 'skytemple/data'),
+    (os.path.join(pkg_path, 'data'), 'data'),
+    (os.path.join(pkg_path, '*.glade'), '.'),
+    (os.path.join(pkg_path, '*.css'), '.'),
+    (os.path.join(site_packages, 'skytemple_icons', 'hicolor'), 'skytemple_icons/hicolor'),
+    (os.path.join(site_packages, 'skytemple_ssb_debugger', 'data'), 'skytemple_ssb_debugger/data'),
+    (os.path.join(site_packages, 'skytemple_ssb_debugger', '*.glade'), 'skytemple_ssb_debugger'),
+    (os.path.join(site_packages, 'skytemple_ssb_debugger', '*.lang'), 'skytemple_ssb_debugger'),
+    (os.path.join(site_packages, 'skytemple_ssb_debugger', 'controller', '*.glade'), 'skytemple_ssb_debugger/controller'),
+    (os.path.join(site_packages, 'skytemple_files', '_resources'), 'skytemple_files/_resources'),
+    (os.path.join('.', 'armips'), 'skytemple_files/_resources'),
+    (os.path.join(site_packages, 'desmume', 'frontend', 'control_ui', '*.glade'), 'desmume/frontend/control_ui'),
+    (os.path.join(site_packages, "cairocffi", "VERSION"), "cairocffi"),
+    (os.path.join(site_packages, "cssselect2", "VERSION"), "cssselect2"),
+    (os.path.join(site_packages, "tinycss2", "VERSION"), "tinycss2"),
+    (os.path.join(site_packages, "cairosvg", "VERSION"), "cairosvg"),
+    (os.path.join(site_packages, "pygal", "css", "*"), 'pygal/css'),
+
+    # Themes
+    ('Mojave-dark', 'share/themes/Mojave-dark'),
+    ('Mojave-light', 'share/themes/Mojave-light'),
+]
+
+additional_binaries = [
+    (os.path.join(site_packages, "desmume", "libdesmume.so"), "."),
+    (os.path.join(os.sep, "usr", "local", "lib", "libSDL.dylib"), "."), # Must be installed with Homebrew
+    (os.path.join(os.sep, "usr", "local", "lib", "libenchant-2.dylib"), "."), # Must be installed with Homebrew
+    (os.path.join(os.sep, "usr", "local", "opt", "cairo", "lib", "libcairo.2.dylib"), "."),
+    (os.path.join(site_packages, "skytemple_tilequant", "aikku", "libtilequant.so"), "skytemple_tilequant/aikku"),
+]
+
+# Add all module *.glade files.
+for (path, directories, filenames) in os.walk(os.path.join(pkg_path, 'module')):
+    for filename in filenames:
+        if filename.endswith('.glade'):
+            additional_datas.append((os.path.abspath(os.path.join('..', path, filename)),
+                                     f'skytemple/{str(PurePosixPath(Path(path.replace(pkg_path + "/", ""))))}'))
+
+block_cipher = None
+
+
+a = Analysis(['../skytemple/main.py'],
+             pathex=[os.path.abspath(os.path.join('..', 'skytemple'))],
+             binaries=additional_binaries,
+             datas=additional_datas,
+             hiddenimports=['pkg_resources.py2_warn', 'packaging.version', 'packaging.specifiers',
+                            'packaging.requirements', 'packaging.markers', '_sysconfigdata__win32_', 'win32api'],
+             hookspath=[],
+             runtime_hooks=[],
+             excludes=[],
+             cipher=block_cipher,
+             noarchive=False)
+
+pyz = PYZ(a.pure, a.zipped_data,
+          cipher=block_cipher)
+
+exe = EXE(pyz,
+          a.scripts,
+          [],
+          exclude_binaries=True,
+          name='run_skytemple',
+          debug=False,
+          bootloader_ignore_signals=False,
+          strip=False,
+          upx=True,
+          console=True)
+
+coll = COLLECT(exe,
+               a.binaries,
+               a.zipfiles,
+               a.datas,
+               strip=False,
+               upx=True,
+               upx_exclude=[],
+               name='skytemple')
+
+app = BUNDLE(coll,
+             name='SkyTemple.app',
+             icon='skytemple.icns',
+             bundle_identifier='de.parakoopa.skytemple')
+

--- a/requirements-mac.txt
+++ b/requirements-mac.txt
@@ -1,0 +1,12 @@
+ndspy==3.0.0
+skytemple-files==0.1.0rc1
+skytemple-dtef==0.1.0rc1
+skytemple-icons==0.1.0
+pycairo==1.18.2
+natsort==7.0.0
+tilequant==0.4.0
+skytemple-ssb-debugger==0.1.0rc1
+skytemple-eventserver >= 0.1.0rc2
+pypresence==4.0.0
+pygal==2.4.0
+CairoSVG==2.4.2

--- a/skytemple/core/ui_utils.py
+++ b/skytemple/core/ui_utils.py
@@ -16,6 +16,7 @@
 #  You should have received a copy of the GNU General Public License
 #  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
 import os
+import sys
 
 import pkg_resources
 from gi.repository import Gtk
@@ -88,8 +89,11 @@ def add_dialog_xml_filter(dialog):
 
 
 def data_dir():
+    if sys.platform.startswith('darwin'):
+        if getattr(sys, 'frozen', False):
+            return os.path.join(os.path.dirname(sys.executable), 'data')
+    
     return os.path.join(os.path.dirname(__file__), '..', 'data')
-
 
 def is_dark_theme(widget):
     style_ctx = widget.get_style_context()

--- a/skytemple/main.py
+++ b/skytemple/main.py
@@ -71,6 +71,10 @@ def main():
         # Load theming under macOS
         _macos_load_theme(settings)
 
+        # The search path is wrong if SkyTemple is executed as an .app bundle
+        if getattr(sys, 'frozen', False):
+            path = os.path.dirname(sys.executable)
+
     itheme: Gtk.IconTheme = Gtk.IconTheme.get_default()
     itheme.append_search_path(os.path.abspath(icons()))
     itheme.append_search_path(os.path.abspath(os.path.join(data_dir(), "icons")))


### PR DESCRIPTION
Adds build scripts for building Mac .app bundles with pyinstaller and a CI job.

Note that the bundle of the current master throws a runtime error:
```python
Traceback (most recent call last):
  File "main.py", line 48, in <module>
  File "/usr/local/lib/python3.8/site-packages/PyInstaller/loader/pyimod03_importers.py", line 493, in exec_module
    exec(bytecode, module.__dict__)
  File "controller/main.py", line 43, in <module>
  File "/usr/local/lib/python3.8/site-packages/PyInstaller/loader/pyimod03_importers.py", line 493, in exec_module
    exec(bytecode, module.__dict__)
  File "core/ssb_debugger/manager.py", line 23, in <module>
  File "/usr/local/lib/python3.8/site-packages/PyInstaller/loader/pyimod03_importers.py", line 493, in exec_module
    exec(bytecode, module.__dict__)
  File "core/ssb_debugger/context.py", line 36, in <module>
ImportError: cannot import name 'EXPS_KEYWORDS' from 'skytemple_ssb_debugger.context.abstract' ([...]/SkyTemple.app/Contents/MacOS/skytemple_ssb_debugger/context/abstract.pyc)
```

This should be fixed once the skytemple_ssb_debugger wheel is updated (it works when pip-installing the skytemple_ssb_debugger master).