### PR TITLE
Basic support for monochrome font files

### DIFF
--- a/skytemple/module/misc_graphics/controller/font.glade
+++ b/skytemple/module/misc_graphics/controller/font.glade
@@ -85,18 +85,6 @@ you want to add in the table: </property>
       <action-widget response="-6">btn_cancel</action-widget>
     </action-widgets>
   </object>
-  <object class="GtkListStore" id="entry_store">
-    <columns>
-      <!-- column-name entry_1 -->
-      <column type="gint"/>
-      <!-- column-name entry_2 -->
-      <column type="gint"/>
-      <!-- column-name entry_3 -->
-      <column type="gint"/>
-      <!-- column-name entry_4 -->
-      <column type="gint"/>
-    </columns>
-  </object>
   <object class="GtkListStore" id="table_store">
     <columns>
       <!-- column-name id -->
@@ -216,7 +204,6 @@ you want to add in the table: </property>
                           <object class="GtkTreeView" id="entry_tree">
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
-                            <property name="model">entry_store</property>
                             <property name="search_column">0</property>
                             <signal name="cursor-changed" handler="on_entry_tree_selection_changed" swapped="no"/>
                             <signal name="select-all" handler="on_entry_tree_selection_changed" swapped="no"/>

--- a/skytemple/module/misc_graphics/controller/font.glade
+++ b/skytemple/module/misc_graphics/controller/font.glade
@@ -1,0 +1,368 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.2 -->
+<interface>
+  <requires lib="gtk+" version="3.20"/>
+  <object class="GtkDialog" id="dialog_choose_char">
+    <property name="can_focus">False</property>
+    <property name="type_hint">dialog</property>
+    <child type="titlebar">
+      <placeholder/>
+    </child>
+    <child internal-child="vbox">
+      <object class="GtkBox">
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">2</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox">
+            <property name="can_focus">False</property>
+            <property name="layout_style">end</property>
+            <child>
+              <object class="GtkButton" id="btn_ok">
+                <property name="label">gtk-ok</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_stock">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="btn_cancel">
+                <property name="label">gtk-cancel</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_stock">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="halign">start</property>
+            <property name="label" translatable="yes">Choose which character
+you want to add in the table: </property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkSpinButton" id="entry_char_id">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <signal name="changed" handler="on_entry_char_id_changed" swapped="no"/>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <action-widgets>
+      <action-widget response="-5">btn_ok</action-widget>
+      <action-widget response="-6">btn_cancel</action-widget>
+    </action-widgets>
+  </object>
+  <object class="GtkListStore" id="entry_store">
+    <columns>
+      <!-- column-name entry_1 -->
+      <column type="gint"/>
+      <!-- column-name entry_2 -->
+      <column type="gint"/>
+      <!-- column-name entry_3 -->
+      <column type="gint"/>
+      <!-- column-name entry_4 -->
+      <column type="gint"/>
+    </columns>
+  </object>
+  <object class="GtkListStore" id="table_store">
+    <columns>
+      <!-- column-name id -->
+      <column type="guint"/>
+      <!-- column-name description -->
+      <column type="gchararray"/>
+    </columns>
+  </object>
+  <object class="GtkPaned" id="editor">
+    <property name="visible">True</property>
+    <property name="can_focus">True</property>
+    <child>
+      <object class="GtkFrame">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="margin_start">5</property>
+        <property name="margin_end">5</property>
+        <property name="margin_top">5</property>
+        <property name="margin_bottom">5</property>
+        <property name="label_xalign">0</property>
+        <property name="shadow_type">none</property>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="orientation">vertical</property>
+            <child>
+              <object class="GtkToolbar">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="show_arrow">False</property>
+                <property name="icon_size">2</property>
+                <child>
+                  <object class="GtkToolButton" id="import">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="is_important">True</property>
+                    <property name="label" translatable="yes">Import</property>
+                    <property name="use_underline">True</property>
+                    <property name="icon_name">skytemple-import-symbolic</property>
+                    <signal name="clicked" handler="on_import_clicked" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="homogeneous">True</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkToolButton" id="export">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="is_important">True</property>
+                    <property name="label" translatable="yes">Export</property>
+                    <property name="use_underline">True</property>
+                    <property name="icon_name">skytemple-export-symbolic</property>
+                    <signal name="clicked" handler="on_export_clicked" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="homogeneous">True</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <child>
+                  <object class="GtkScrolledWindow">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="hexpand">True</property>
+                    <property name="vexpand">True</property>
+                    <property name="shadow_type">in</property>
+                    <property name="propagate_natural_width">True</property>
+                    <property name="propagate_natural_height">True</property>
+                    <child>
+                      <object class="GtkViewport">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <child>
+                          <object class="GtkDrawingArea" id="draw">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="orientation">vertical</property>
+                    <child>
+                      <object class="GtkScrolledWindow">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="hexpand">True</property>
+                        <property name="vexpand">True</property>
+                        <property name="shadow_type">in</property>
+                        <property name="propagate_natural_width">True</property>
+                        <property name="propagate_natural_height">True</property>
+                        <child>
+                          <object class="GtkTreeView" id="entry_tree">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="model">entry_store</property>
+                            <property name="search_column">0</property>
+                            <signal name="cursor-changed" handler="on_entry_tree_selection_changed" swapped="no"/>
+                            <signal name="select-all" handler="on_entry_tree_selection_changed" swapped="no"/>
+                            <signal name="unselect-all" handler="on_entry_tree_selection_changed" swapped="no"/>
+                            <child internal-child="selection">
+                              <object class="GtkTreeSelection">
+                                <property name="mode">multiple</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="spacing">5</property>
+                        <child>
+                          <object class="GtkButton" id="btn_add">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">True</property>
+                            <property name="tooltip_text" translatable="yes">Reload</property>
+                            <signal name="clicked" handler="on_btn_add_clicked" swapped="no"/>
+                            <child>
+                              <object class="GtkImage">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="icon_name">skytemple-list-add-symbolic</property>
+                              </object>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="pack_type">end</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkButton" id="btn_remove">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">True</property>
+                            <property name="tooltip_text" translatable="yes">Reload</property>
+                            <signal name="clicked" handler="on_btn_remove_clicked" swapped="no"/>
+                            <child>
+                              <object class="GtkImage">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="icon_name">skytemple-list-remove-symbolic</property>
+                              </object>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="pack_type">end</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkGrid">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">end</property>
+                    <property name="label" translatable="yes">Table: </property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkComboBox" id="cb_table_select">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="model">table_store</property>
+                    <signal name="changed" handler="on_font_table_changed" swapped="no"/>
+                    <child>
+                      <object class="GtkCellRendererText" id="table"/>
+                      <attributes>
+                        <attribute name="text">1</attribute>
+                      </attributes>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">0</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+          </object>
+        </child>
+        <child type="label">
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="label" translatable="yes">Font</property>
+          </object>
+        </child>
+      </object>
+      <packing>
+        <property name="resize">True</property>
+        <property name="shrink">False</property>
+      </packing>
+    </child>
+    <child>
+      <placeholder/>
+    </child>
+  </object>
+</interface>

--- a/skytemple/module/misc_graphics/controller/font.py
+++ b/skytemple/module/misc_graphics/controller/font.py
@@ -1,0 +1,278 @@
+#  Copyright 2020 Parakoopa
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+import logging
+import os
+import sys
+from typing import TYPE_CHECKING, Optional, Dict
+
+from xml.etree.ElementTree import Element, ElementTree
+from skytemple_files.common.xml_util import prettify
+
+import cairo
+
+from skytemple.core.error_handler import display_error
+from skytemple_files.graphics.fonts.abstract import AbstractFont
+
+try:
+    from PIL import Image
+except:
+    from pil import Image
+from gi.repository import Gtk
+from gi.repository.Gtk import ResponseType
+
+from skytemple.controller.main import MainController
+from skytemple.core.img_utils import pil_to_cairo_surface
+from skytemple.core.module_controller import AbstractController
+
+logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from skytemple.module.misc_graphics.module import MiscGraphicsModule, FontOpenSpec
+
+
+IMAGE_ZOOM = 2
+COLUMN_TITLE = {"char": "Char ID", "width": "Width", "bprow": "Bytes per row", "cat": "Category", "padding": "Padding"}
+class FontController(AbstractController):
+    def __init__(self, module: 'MiscGraphicsModule', item: 'FontOpenSpec'):
+        self.module = module
+        self.spec = item
+        self.font: Optional[AbstractFont] = self.module.get_font(self.spec)
+        
+        self.builder = None
+
+    def get_view(self) -> Gtk.Widget:
+        self.builder = self._get_builder(__file__, 'font.glade')
+        self._init_font()
+
+        # Generate Automatically the columns since we don't know what properties we will be using
+        self.entry_properties = self.font.get_entry_properties()
+        tree_store = Gtk.ListStore(*([str]*len(self.entry_properties)))
+        entry_tree: Gtk.TreeView = self.builder.get_object('entry_tree')
+        entry_tree.set_model(tree_store)
+        self._column_mapping: List[Tuple[Gtk.CellRendererText, str]] = []
+        for i, p in enumerate(self.entry_properties):
+            renderer = Gtk.CellRendererText(editable=(p!="char"))
+            renderer.connect("edited", self.on_row_value_changed)
+            column = Gtk.TreeViewColumn(COLUMN_TITLE[p], renderer, text=i)
+            self._column_mapping.append((renderer, p))
+            entry_tree.append_column(column)
+        
+        self._switch_table()
+        self.builder.connect_signals(self)
+        self.builder.get_object('draw').connect('draw', self.draw)
+        return self.builder.get_object('editor')
+
+    def on_export_clicked(self, w: Gtk.MenuToolButton):
+        dialog = Gtk.FileChooserDialog(
+            "Export font in folder...",
+            MainController.window(),
+            Gtk.FileChooserAction.SELECT_FOLDER,
+            (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL, Gtk.STOCK_SAVE, Gtk.ResponseType.OK)
+        )
+
+        response = dialog.run()
+        fn = dialog.get_filename()
+        dialog.destroy()
+
+        if response == Gtk.ResponseType.OK:
+            xml, tables = self.font.export_to_xml()
+            with open(os.path.join(fn, f'char_tables.xml'), 'w') as f:
+                f.write(prettify(xml))
+            for i, table in tables.items():
+                table.save(os.path.join(fn, f'table-{i}.png'))
+            
+    def on_import_clicked(self, w: Gtk.MenuToolButton):
+        md = Gtk.MessageDialog(
+            MainController.window(),
+            Gtk.DialogFlags.DESTROY_WITH_PARENT, Gtk.MessageType.INFO,
+            Gtk.ButtonsType.OK,
+            f"To import, select a folder containing all the files that were created when exporting the font.",
+            title="Import Font"
+        )
+        md.run()
+        md.destroy()
+        dialog = Gtk.FileChooserDialog(
+            "Import font from folder...",
+            MainController.window(),
+            Gtk.FileChooserAction.SELECT_FOLDER,
+            (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL, Gtk.STOCK_OPEN, Gtk.ResponseType.OK)
+        )
+
+        response = dialog.run()
+        fn = dialog.get_filename()
+        dialog.destroy()
+
+        if response == Gtk.ResponseType.OK:
+            try:
+                xml = ElementTree().parse(os.path.join(fn, f'char_tables.xml'))
+                tables = dict()
+                for i in range(256):
+                    path = os.path.join(fn, f'table-{i}.png')
+                    if os.path.exists(path):
+                        tables[i] = Image.open(path, 'r')
+                        
+                self.font.import_from_xml(xml, tables)
+                self.module.mark_font_as_modified(self.spec)
+            except Exception as err:
+                display_error(
+                    sys.exc_info(),
+                    str(err),
+                    "Error importing font."
+                )
+            self._init_font()
+        
+    def _init_font(self):
+        # Init available tables
+        self.tables = self.font.to_pil()
+        
+        cb_store: Gtk.ListStore = self.builder.get_object('table_store')
+        cb: Gtk.ComboBoxText = self.builder.get_object('cb_table_select')
+        self._fill_available_font_tables_into_store(cb_store)
+        
+        cb.set_active(0)
+
+    def _add_property_row(self, store, entry):
+        prop = entry.get_properties()
+        row = [None]*len(self.entry_properties)
+        for i, c in enumerate(self.entry_properties):
+            if c in prop:
+                row[i] = str(prop[c])
+        store.append(row)
+        
+    def _switch_table(self):
+        cb_store: Gtk.ListStore = self.builder.get_object('table_store')
+        cb: Gtk.ComboBoxText = self.builder.get_object('cb_table_select')
+        if cb.get_active_iter()!=None:
+            v : int = cb_store[cb.get_active_iter()][0]
+            self.entries = self.font.get_entries_from_table(v)
+            
+            entry_tree: Gtk.TreeView = self.builder.get_object('entry_tree')
+            store: Gtk.ListStore = entry_tree.get_model()
+            store.clear()
+            
+            for e in self.entries:
+                self._add_property_row(store, e)
+            surface = self.tables[v].resize((self.tables[v].width*IMAGE_ZOOM, self.tables[v].height*IMAGE_ZOOM))
+            self.surface = pil_to_cairo_surface(surface.convert('RGBA'))
+            self.builder.get_object('draw').queue_draw()
+
+    def on_entry_char_id_changed(self, widget):
+        try:
+            val = int(widget.get_text())
+        except ValueError:
+            val = -1
+        
+        if val<0:
+            val = 0
+            widget.set_text(str(val))
+        elif val>=256:
+            val=255
+            widget.set_text(str(val))
+        
+    def on_btn_add_clicked(self, widget):
+        dialog: Gtk.Dialog = self.builder.get_object('dialog_choose_char')
+
+        self.builder.get_object('entry_char_id').set_text(str(0))
+        self.builder.get_object('entry_char_id').set_increments(1,1)
+        self.builder.get_object('entry_char_id').set_range(0, 255)
+        
+        dialog.set_attached_to(MainController.window())
+        dialog.set_transient_for(MainController.window())
+
+        resp = dialog.run()
+        dialog.hide()
+        if resp == ResponseType.OK:
+            cb_store: Gtk.ListStore = self.builder.get_object('table_store')
+            cb: Gtk.ComboBoxText = self.builder.get_object('cb_table_select')
+            v : int = cb_store[cb.get_active_iter()][0]
+            char = int(self.builder.get_object('entry_char_id').get_text())
+            try:
+                for e in self.entries:
+                    if e.get_properties()["char"]==char:
+                        raise ValueError(f"Character {char} already exists in the table!")
+                entry = self.font.create_entry_for_table(v)
+                entry.set_properties({"char": char})
+                self.entries.append(entry)
+                
+                entry_tree: Gtk.TreeView = self.builder.get_object('entry_tree')
+                store: Gtk.ListStore = entry_tree.get_model()
+                self._add_property_row(store, entry)
+                self.module.mark_font_as_modified(self.spec)
+            except Exception as err:
+                display_error(
+                    sys.exc_info(),
+                    str(err),
+                    "Error adding character."
+                )
+    
+    def on_btn_remove_clicked(self, widget):
+        # Deletes all selected font entries
+        # Allows multiple deletions
+        entry_tree: Gtk.TreeView = self.builder.get_object('entry_tree')
+        active_rows : List[Gtk.TreePath] = entry_tree.get_selection().get_selected_rows()[1]
+        store: Gtk.ListStore = entry_tree.get_model()
+        for x in sorted(active_rows, key=lambda x:-x.get_indices()[0]):
+            elt = self.entries[x.get_indices()[0]]
+            self.font.delete_entry(elt)
+            del self.entries[x.get_indices()[0]]
+            del store[x.get_indices()[0]]
+        self.module.mark_font_as_modified(self.spec)
+        self.tables = self.font.to_pil()
+        self._switch_table()
+
+    def on_row_value_changed(self, widget, path, text):
+        try:
+            int(text)
+        except ValueError:
+            return
+        entry_tree: Gtk.TreeView = self.builder.get_object('entry_tree')
+        store: Gtk.ListStore = entry_tree.get_model()
+        for i, c in enumerate(self._column_mapping):
+            if widget==c[0]:
+                store[path][i] = text
+                self.entries[int(path)].set_properties({c[1]: int(text)})
+        self.module.mark_font_as_modified(self.spec)
+        self.builder.get_object('draw').queue_draw()
+        
+    def on_entry_tree_selection_changed(self, *args):
+        self.builder.get_object('draw').queue_draw()
+        
+    def on_font_table_changed(self, widget):
+        self._switch_table()
+    
+    def _fill_available_font_tables_into_store(self, cb_store):
+        # Init combobox
+        cb_store.clear()
+        for v in self.tables.keys():
+            cb_store.append([v, f'Table {v}'])
+    
+    def draw(self, wdg, ctx: cairo.Context, *args):
+        if self.surface:
+            wdg.set_size_request(self.surface.get_width(), self.surface.get_height())
+            ctx.fill()
+            ctx.set_source_surface(self.surface, 0, 0)
+            ctx.get_source().set_filter(cairo.Filter.NEAREST)
+            ctx.paint()
+            entry_tree: Gtk.TreeView = self.builder.get_object('entry_tree')
+            active_rows : List[Gtk.TreePath] = entry_tree.get_selection().get_selected_rows()[1]
+            for x in active_rows:
+                prop = self.entries[x.get_indices()[0]].get_properties()
+                ctx.set_line_width(1)
+                ctx.set_source_rgba(1,0,0, 1)
+                ctx.rectangle((prop["char"]%16)*12*IMAGE_ZOOM, (prop["char"]//16)*12*IMAGE_ZOOM, prop["width"]*IMAGE_ZOOM, 12*IMAGE_ZOOM)
+                ctx.stroke()
+        return True


### PR DESCRIPTION
See SkyTemple/skytemple-files#39.

This provides: 
 - support for editing monochrome font files, under the "Misc. Graphics" section;
 - import and export of those files;
 - basic character table viewer and editor.

Pull request mentioned above must be merged for this to work.