### PR TITLE
Add support to edit graphic fonts

### DIFF
--- a/skytemple/module/misc_graphics/controller/font.py
+++ b/skytemple/module/misc_graphics/controller/font.py
@@ -100,7 +100,8 @@ class FontController(AbstractController):
             MainController.window(),
             Gtk.DialogFlags.DESTROY_WITH_PARENT, Gtk.MessageType.INFO,
             Gtk.ButtonsType.OK,
-            f"To import, select a folder containing all the files that were created when exporting the font.",
+            f"To import, select a folder containing all the files that were created when exporting the font.\n"
+            f"IMPORTANT: All image files must be indexed PNGs!",
             title="Import Font"
         )
         md.run()

--- a/skytemple/module/misc_graphics/controller/graphic_font.glade
+++ b/skytemple/module/misc_graphics/controller/graphic_font.glade
@@ -1,0 +1,277 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.22.2 -->
+<interface>
+  <requires lib="gtk+" version="3.20"/>
+  <object class="GtkDialog" id="dialog_import">
+    <property name="can_focus">False</property>
+    <property name="type_hint">dialog</property>
+    <child type="titlebar">
+      <placeholder/>
+    </child>
+    <child internal-child="vbox">
+      <object class="GtkBox">
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">2</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox">
+            <property name="can_focus">False</property>
+            <property name="layout_style">end</property>
+            <child>
+              <object class="GtkButton" id="btn_ok">
+                <property name="label">gtk-ok</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_stock">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="btn_cancel">
+                <property name="label">gtk-cancel</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_stock">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="halign">start</property>
+            <property name="label" translatable="yes">Choose how many characters
+will be in the list: </property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkSpinButton" id="nb_entries_import">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <signal name="changed" handler="on_nb_entries_import_changed" swapped="no"/>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <action-widgets>
+      <action-widget response="-5">btn_ok</action-widget>
+      <action-widget response="-6">btn_cancel</action-widget>
+    </action-widgets>
+  </object>
+  <object class="GtkPaned" id="editor">
+    <property name="visible">True</property>
+    <property name="can_focus">True</property>
+    <child>
+      <object class="GtkFrame">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="margin_start">5</property>
+        <property name="margin_end">5</property>
+        <property name="margin_top">5</property>
+        <property name="margin_bottom">5</property>
+        <property name="label_xalign">0</property>
+        <property name="shadow_type">none</property>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="orientation">vertical</property>
+            <child>
+              <object class="GtkToolbar">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="show_arrow">False</property>
+                <property name="icon_size">2</property>
+                <child>
+                  <object class="GtkToolButton" id="import">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="is_important">True</property>
+                    <property name="label" translatable="yes">Import</property>
+                    <property name="use_underline">True</property>
+                    <property name="icon_name">skytemple-import-symbolic</property>
+                    <signal name="clicked" handler="on_import_clicked" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="homogeneous">True</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkToolButton" id="export">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="is_important">True</property>
+                    <property name="label" translatable="yes">Export</property>
+                    <property name="use_underline">True</property>
+                    <property name="icon_name">skytemple-export-symbolic</property>
+                    <signal name="clicked" handler="on_export_clicked" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="homogeneous">True</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkStack" id="entry_stack">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <child>
+                  <object class="GtkLabel" id="no_entry_label">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">This entry is empty.</property>
+                    <property name="justify">center</property>
+                  </object>
+                  <packing>
+                    <property name="name">page0</property>
+                    <property name="title" translatable="yes">page0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox" id="entry_viewer">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="orientation">vertical</property>
+                    <property name="spacing">10</property>
+                    <child>
+                      <object class="GtkScrolledWindow">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="hexpand">True</property>
+                        <property name="vexpand">True</property>
+                        <property name="shadow_type">in</property>
+                        <property name="propagate_natural_width">True</property>
+                        <property name="propagate_natural_height">True</property>
+                        <child>
+                          <object class="GtkViewport">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <child>
+                              <object class="GtkDrawingArea" id="draw">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="name">page1</property>
+                    <property name="title" translatable="yes">page1</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkGrid">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">end</property>
+                    <property name="label" translatable="yes">Entry: </property>
+                  </object>
+                  <packing>
+                    <property name="left_attach">0</property>
+                    <property name="top_attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkSpinButton" id="entry_id">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <signal name="changed" handler="on_entry_id_changed" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="left_attach">1</property>
+                    <property name="top_attach">0</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+          </object>
+        </child>
+        <child type="label">
+          <object class="GtkLabel">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="label" translatable="yes">Font</property>
+          </object>
+        </child>
+      </object>
+      <packing>
+        <property name="resize">True</property>
+        <property name="shrink">False</property>
+      </packing>
+    </child>
+    <child>
+      <placeholder/>
+    </child>
+  </object>
+  <object class="GtkListStore" id="table_store">
+    <columns>
+      <!-- column-name id -->
+      <column type="guint"/>
+      <!-- column-name description -->
+      <column type="gchararray"/>
+    </columns>
+  </object>
+</interface>

--- a/skytemple/module/misc_graphics/controller/graphic_font.py
+++ b/skytemple/module/misc_graphics/controller/graphic_font.py
@@ -1,0 +1,190 @@
+#  Copyright 2020 Parakoopa
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+import logging
+import os
+import sys
+from typing import TYPE_CHECKING, Optional, Dict
+
+from xml.etree.ElementTree import Element, ElementTree
+from skytemple_files.common.xml_util import prettify
+
+import cairo
+
+from skytemple.core.error_handler import display_error
+from skytemple_files.graphics.fonts.abstract import AbstractFont
+
+try:
+    from PIL import Image
+except:
+    from pil import Image
+from gi.repository import Gtk
+from gi.repository.Gtk import ResponseType
+
+from skytemple.controller.main import MainController
+from skytemple.core.img_utils import pil_to_cairo_surface
+from skytemple.core.module_controller import AbstractController
+
+logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from skytemple.module.misc_graphics.module import MiscGraphicsModule, FontOpenSpec
+
+
+IMAGE_ZOOM = 4
+MAX_ENTRIES = 10000
+class GraphicFontController(AbstractController):
+    def __init__(self, module: 'MiscGraphicsModule', item: 'FontOpenSpec'):
+        self.module = module
+        self.spec = item
+        self.font: Optional[AbstractFont] = self.module.get_font(self.spec)
+        
+        self.builder = None
+
+    def get_view(self) -> Gtk.Widget:
+        self.builder = self._get_builder(__file__, 'graphic_font.glade')
+
+        self._init_font()
+        
+        self.builder.connect_signals(self)
+        self.builder.get_object('draw').connect('draw', self.draw)
+        return self.builder.get_object('editor')
+
+    def on_export_clicked(self, w: Gtk.MenuToolButton):
+        dialog = Gtk.FileChooserDialog(
+            "Export font in folder...",
+            MainController.window(),
+            Gtk.FileChooserAction.SELECT_FOLDER,
+            (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL, Gtk.STOCK_SAVE, Gtk.ResponseType.OK)
+        )
+
+        response = dialog.run()
+        fn = dialog.get_filename()
+        dialog.destroy()
+
+        if response == Gtk.ResponseType.OK:
+            for i in range(self.font.get_nb_entries()):
+                e = self.font.get_entry(i)
+                if e:
+                    path = os.path.join(fn, f'{i:0>4}.png')
+                    e.save(path)
+            
+    def on_import_clicked(self, w: Gtk.MenuToolButton):
+        md = Gtk.MessageDialog(
+            MainController.window(),
+            Gtk.DialogFlags.DESTROY_WITH_PARENT, Gtk.MessageType.INFO,
+            Gtk.ButtonsType.OK,
+            f"To import, select a folder containing all the files that were created when exporting the font.\n"
+            f"IMPORTANT: All image files must be indexed PNGs and use the same palette!",
+            title="Import Font"
+        )
+        md.run()
+        md.destroy()
+        dialog = Gtk.FileChooserDialog(
+            "Import font from folder...",
+            MainController.window(),
+            Gtk.FileChooserAction.SELECT_FOLDER,
+            (Gtk.STOCK_CANCEL, Gtk.ResponseType.CANCEL, Gtk.STOCK_OPEN, Gtk.ResponseType.OK)
+        )
+
+        response = dialog.run()
+        fn = dialog.get_filename()
+        dialog.destroy()
+
+        if response == Gtk.ResponseType.OK:
+            dialog: Gtk.Dialog = self.builder.get_object('dialog_import')
+
+            self.builder.get_object('nb_entries_import').set_increments(1,1)
+            self.builder.get_object('nb_entries_import').set_range(1, MAX_ENTRIES-1)
+            self.builder.get_object('nb_entries_import').set_text(str(self.font.get_nb_entries()))
+            
+            dialog.set_attached_to(MainController.window())
+            dialog.set_transient_for(MainController.window())
+
+            resp = dialog.run()
+            dialog.hide()
+            if resp == Gtk.ResponseType.OK:
+                try:
+                    lst_entries = []
+                    for i in range(int(self.builder.get_object('nb_entries_import').get_text())):
+                        path = os.path.join(fn, f'{i:0>4}.png')
+                        if os.path.exists(path):
+                            lst_entries.append(Image.open(path, 'r'))
+                        else:
+                            lst_entries.append(None)
+                    self.font.set_entries(lst_entries)
+                    self.module.mark_font_as_modified(self.spec)
+                except Exception as err:
+                    display_error(
+                        sys.exc_info(),
+                        str(err),
+                        "Error importing font."
+                    )
+                self._init_font()
+
+    def _init_font(self):
+        self.builder.get_object('entry_id').set_text(str(0))
+        self.builder.get_object('entry_id').set_increments(1,1)
+        self.builder.get_object('entry_id').set_range(0, self.font.get_nb_entries()-1)
+        self._switch_entry()
+
+    def on_entry_id_changed(self, widget):
+        try:
+            val = int(widget.get_text())
+        except ValueError:
+            val = -1
+        
+        if val<0:
+            val = 0
+            widget.set_text(str(val))
+        elif val>=self.font.get_nb_entries():
+            val=self.font.get_nb_entries()-1
+            widget.set_text(str(val))
+        self._switch_entry()
+            
+    def on_nb_entries_import_changed(self, widget):
+        try:
+            val = int(widget.get_text())
+        except ValueError:
+            val = -1
+        
+        if val<=0:
+            val = 1
+            widget.set_text(str(val))
+        elif val>=MAX_ENTRIES+1:
+            val=MAX_ENTRIES
+            widget.set_text(str(val))
+        
+    def _switch_entry(self):
+        surface = self.font.get_entry(int(self.builder.get_object('entry_id').get_text()))
+        stack: Gtk.Stack = self.builder.get_object('entry_stack')
+        if surface:
+            stack.set_visible_child(self.builder.get_object('entry_viewer'))
+            surface = surface.resize((surface.width*IMAGE_ZOOM, surface.height*IMAGE_ZOOM))
+            self.surface = pil_to_cairo_surface(surface.convert('RGBA'))
+            self.builder.get_object('draw').queue_draw()
+        else:
+            stack.set_visible_child(self.builder.get_object('no_entry_label'))
+            self.surface = pil_to_cairo_surface(Image.new('RGBA', size=(1,1)))
+    
+    def draw(self, wdg, ctx: cairo.Context, *args):
+        if self.surface:
+            wdg.set_size_request(self.surface.get_width(), self.surface.get_height())
+            ctx.fill()
+            ctx.set_source_surface(self.surface, 0, 0)
+            ctx.get_source().set_filter(cairo.Filter.NEAREST)
+            ctx.paint()
+        return True

--- a/skytemple/module/misc_graphics/controller/zmappat.py
+++ b/skytemple/module/misc_graphics/controller/zmappat.py
@@ -108,7 +108,8 @@ class ZMappaTController(AbstractController):
             MainController.window(),
             Gtk.DialogFlags.DESTROY_WITH_PARENT, Gtk.MessageType.INFO,
             Gtk.ButtonsType.OK,
-            f"To import, select a folder containing all the image files that were created when exporting the minimized version.",
+            f"To import, select a folder containing all the image files that were created when exporting the minimized version.\n"
+            f"IMPORTANT: All image files must be indexed PNGs and use the same palette!",
             title="Import Minimized Version"
         )
         md.run()


### PR DESCRIPTION
See pull request SkyTemple/skytemple-files#40.

UI support for graphic font files, under the "Misc. Graphics" section:
- an entry viewer;
- import/export buttons to edit images from those files.