### PR TITLE
Fix broken library reference on macOS, improvements for Big Sur

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -166,8 +166,6 @@ jobs:
           cd installer
 
           # Install themes
-          curl https://skytemple.org/build_deps/mac/McMojave.zip -O
-          unzip McMojave.zip > /dev/null
           curl https://skytemple.org/build_deps/Arc.zip -O
           unzip Arc.zip > /dev/null
 

--- a/installer/skytemple-mac.spec
+++ b/installer/skytemple-mac.spec
@@ -30,8 +30,6 @@ additional_datas = [
     (os.path.join(site_packages, "pygal", "css", "*"), 'pygal/css'),
 
     # Themes
-    ('Mojave-dark', 'share/themes/Mojave-dark'),
-    ('Mojave-light', 'share/themes/Mojave-light'),
     ('Arc', 'share/themes/Arc'),
     ('Arc-Dark', 'share/themes/Arc-Dark'),
 ]

--- a/installer/skytemple-mac.spec
+++ b/installer/skytemple-mac.spec
@@ -38,7 +38,7 @@ additional_datas = [
 
 additional_binaries = [
     (os.path.join(site_packages, "desmume", "libdesmume.so"), "."),
-    (os.path.join(os.sep, "usr", "local", "lib", "libSDL.dylib"), "."), # Must be installed with Homebrew
+    (os.path.join(os.sep, "usr", "local", "lib", "libSDL-1.2.0.dylib"), "."), # Must be installed with Homebrew
     (os.path.join(os.sep, "usr", "local", "lib", "libenchant-2.dylib"), "."), # Must be installed with Homebrew
     (os.path.join(os.sep, "usr", "local", "lib", "libaspell.15.dylib"), "."), # Gets installed with Enchant
     (os.path.join(os.sep, "usr", "local", "lib", "enchant-2", "enchant_applespell.so"), "."), # Gets installed with Enchant

--- a/skytemple/controller/main.py
+++ b/skytemple/controller/main.py
@@ -109,7 +109,11 @@ class MainController:
         self._loaded_map_bg_module = None
         self._current_breadcrumbs = []
 
-        self._load_position_and_size()
+        if not sys.platform.startswith('darwin'):
+            # Don't load the window position on macOS to prevent
+            # the window from getting stuck on a disconnected screen
+            self._load_position_and_size()
+
         self._configure_csd()
         self._load_icon()
         self._load_recent_files()

--- a/skytemple/main.py
+++ b/skytemple/main.py
@@ -58,7 +58,7 @@ def main():
 
     if sys.platform.startswith('win'):
         # Load theming under Windows
-        _windows_load_theme(settings)
+        _load_theme(settings)
         # Solve issue #12
         try:
             from skytemple_files.common.platform_utils.win import win_set_error_mode
@@ -69,7 +69,7 @@ def main():
 
     if sys.platform.startswith('darwin'):
         # Load theming under macOS
-        _macos_load_theme(settings)
+        _load_theme(settings)
 
         # The search path is wrong if SkyTemple is executed as an .app bundle
         if getattr(sys, 'frozen', False):
@@ -128,15 +128,9 @@ def main():
         AsyncTaskRunner.end()
 
 
-def _windows_load_theme(settings: SkyTempleSettingsStore):
+def _load_theme(settings: SkyTempleSettingsStore):
     gtk_settings = Gtk.Settings.get_default()
     gtk_settings.set_property("gtk-theme-name", settings.get_gtk_theme(default='Arc-Dark'))
-
-
-def _macos_load_theme(settings: SkyTempleSettingsStore):
-    gtk_settings = Gtk.Settings.get_default()
-    gtk_settings.set_property("gtk-theme-name", settings.get_gtk_theme(default='Mojave-dark'))
-
 
 if __name__ == '__main__':
     # TODO: At the moment doesn't support any cli arguments.


### PR DESCRIPTION
* Fixed libSDL reference
* Removed the McMojave theme since it looks out of place on the redesigned Big Sur
* Disabled loading window position from config (causes the window to get stuck on a disconnected monitor, see #67)