### PR TITLE
Add Floor Ranks and No Missions attributes

### DIFF
--- a/skytemple/module/dungeon/controller/floor.glade
+++ b/skytemple/module/dungeon/controller/floor.glade
@@ -1,35 +1,35 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.38.2 -->
+<!-- Generated with glade 3.22.2 -->
 <interface>
   <requires lib="gtk+" version="3.22"/>
   <object class="GtkAdjustment" id="adjustment1">
     <property name="upper">100</property>
     <property name="value">0.25</property>
-    <property name="step-increment">0.01</property>
+    <property name="step_increment">0.01</property>
   </object>
   <object class="GtkAdjustment" id="adjustment_empty_monster_house_change">
     <property name="upper">100</property>
-    <property name="page-increment">10</property>
+    <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment_hidden_stairs_change">
     <property name="upper">100</property>
-    <property name="page-increment">10</property>
+    <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment_kecleon_shop_chance">
     <property name="upper">100</property>
-    <property name="page-increment">10</property>
+    <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment_monster_house_chance">
     <property name="upper">100</property>
-    <property name="page-increment">10</property>
+    <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment_sticky_item_change">
     <property name="upper">100</property>
-    <property name="page-increment">10</property>
+    <property name="page_increment">10</property>
   </object>
   <object class="GtkAdjustment" id="adjustment_unusued_change">
     <property name="upper">100</property>
-    <property name="page-increment">10</property>
+    <property name="page_increment">10</property>
   </object>
   <object class="GtkListStore" id="category_add_store">
     <columns>
@@ -40,29 +40,32 @@
     </columns>
   </object>
   <object class="GtkDialog" id="dialog_category_add">
-    <property name="can-focus">False</property>
+    <property name="can_focus">False</property>
     <property name="title" translatable="yes">Add category</property>
     <property name="modal">True</property>
-    <property name="destroy-with-parent">True</property>
-    <property name="type-hint">dialog</property>
-    <property name="skip-taskbar-hint">True</property>
-    <property name="skip-pager-hint">True</property>
+    <property name="destroy_with_parent">True</property>
+    <property name="type_hint">dialog</property>
+    <property name="skip_taskbar_hint">True</property>
+    <property name="skip_pager_hint">True</property>
+    <child type="titlebar">
+      <placeholder/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox">
-        <property name="can-focus">False</property>
+        <property name="can_focus">False</property>
         <property name="orientation">vertical</property>
         <property name="spacing">2</property>
         <child internal-child="action_area">
           <object class="GtkButtonBox">
-            <property name="can-focus">False</property>
-            <property name="layout-style">end</property>
+            <property name="can_focus">False</property>
+            <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="button2">
                 <property name="label">gtk-cancel</property>
                 <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="receives-default">True</property>
-                <property name="use-stock">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_stock">True</property>
               </object>
               <packing>
                 <property name="expand">True</property>
@@ -74,9 +77,9 @@
               <object class="GtkButton" id="button1">
                 <property name="label">gtk-apply</property>
                 <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="receives-default">True</property>
-                <property name="use-stock">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_stock">True</property>
               </object>
               <packing>
                 <property name="expand">True</property>
@@ -94,16 +97,16 @@
         <child>
           <object class="GtkBox">
             <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="margin-start">10</property>
-            <property name="margin-end">10</property>
-            <property name="margin-top">10</property>
-            <property name="margin-bottom">10</property>
+            <property name="can_focus">False</property>
+            <property name="margin_start">10</property>
+            <property name="margin_end">10</property>
+            <property name="margin_top">10</property>
+            <property name="margin_bottom">10</property>
             <property name="spacing">10</property>
             <child>
               <object class="GtkLabel">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Category:</property>
               </object>
               <packing>
@@ -115,7 +118,7 @@
             <child>
               <object class="GtkComboBox" id="category_add_cb">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="model">category_add_store</property>
                 <child>
                   <object class="GtkCellRendererText"/>
@@ -146,7 +149,7 @@
   </object>
   <object class="GtkLabel" id="chance_label1">
     <property name="visible">True</property>
-    <property name="can-focus">False</property>
+    <property name="can_focus">False</property>
     <property name="label" translatable="yes">Chance</property>
     <attributes>
       <attribute name="style" value="italic"/>
@@ -155,7 +158,7 @@
   </object>
   <object class="GtkLabel" id="chance_label2">
     <property name="visible">True</property>
-    <property name="can-focus">False</property>
+    <property name="can_focus">False</property>
     <property name="label" translatable="yes">Chance</property>
     <attributes>
       <attribute name="style" value="italic"/>
@@ -164,7 +167,7 @@
   </object>
   <object class="GtkLabel" id="chance_label3">
     <property name="visible">True</property>
-    <property name="can-focus">False</property>
+    <property name="can_focus">False</property>
     <property name="label" translatable="yes">Chance</property>
     <attributes>
       <attribute name="style" value="italic"/>
@@ -173,7 +176,7 @@
   </object>
   <object class="GtkLabel" id="chance_label4">
     <property name="visible">True</property>
-    <property name="can-focus">False</property>
+    <property name="can_focus">False</property>
     <property name="label" translatable="yes">Chance</property>
     <attributes>
       <attribute name="style" value="italic"/>
@@ -182,7 +185,7 @@
   </object>
   <object class="GtkLabel" id="chance_label5">
     <property name="visible">True</property>
-    <property name="can-focus">False</property>
+    <property name="can_focus">False</property>
     <property name="label" translatable="yes">Chance</property>
     <attributes>
       <attribute name="style" value="italic"/>
@@ -191,7 +194,7 @@
   </object>
   <object class="GtkLabel" id="chance_label6">
     <property name="visible">True</property>
-    <property name="can-focus">False</property>
+    <property name="can_focus">False</property>
     <property name="label" translatable="yes">Chance</property>
     <attributes>
       <attribute name="style" value="italic"/>
@@ -200,7 +203,7 @@
   </object>
   <object class="GtkLabel" id="chance_label7">
     <property name="visible">True</property>
-    <property name="can-focus">False</property>
+    <property name="can_focus">False</property>
     <property name="label" translatable="yes">Chance</property>
     <attributes>
       <attribute name="style" value="italic"/>
@@ -209,7 +212,7 @@
   </object>
   <object class="GtkLabel" id="chance_label8">
     <property name="visible">True</property>
-    <property name="can-focus">False</property>
+    <property name="can_focus">False</property>
     <property name="label" translatable="yes">Chance</property>
     <attributes>
       <attribute name="style" value="italic"/>
@@ -218,7 +221,7 @@
   </object>
   <object class="GtkLabel" id="chance_label9">
     <property name="visible">True</property>
-    <property name="can-focus">False</property>
+    <property name="can_focus">False</property>
     <property name="label" translatable="yes">Chance</property>
     <attributes>
       <attribute name="style" value="italic"/>
@@ -233,7 +236,7 @@
   </object>
   <object class="GtkEntryCompletion" id="completion_item_berries">
     <property name="model">completion_item_berries_store</property>
-    <property name="text-column">0</property>
+    <property name="text_column">0</property>
     <child>
       <object class="GtkCellRendererText"/>
       <attributes>
@@ -249,7 +252,7 @@
   </object>
   <object class="GtkEntryCompletion" id="completion_item_foods">
     <property name="model">completion_item_foods_store</property>
-    <property name="text-column">0</property>
+    <property name="text_column">0</property>
     <child>
       <object class="GtkCellRendererText"/>
       <attributes>
@@ -265,7 +268,7 @@
   </object>
   <object class="GtkEntryCompletion" id="completion_item_hold">
     <property name="model">completion_item_hold_store</property>
-    <property name="text-column">0</property>
+    <property name="text_column">0</property>
     <child>
       <object class="GtkCellRendererText"/>
       <attributes>
@@ -281,7 +284,7 @@
   </object>
   <object class="GtkEntryCompletion" id="completion_item_orbs">
     <property name="model">completion_item_orbs_store</property>
-    <property name="text-column">0</property>
+    <property name="text_column">0</property>
     <child>
       <object class="GtkCellRendererText"/>
       <attributes>
@@ -297,7 +300,7 @@
   </object>
   <object class="GtkEntryCompletion" id="completion_item_others">
     <property name="model">completion_item_others_store</property>
-    <property name="text-column">0</property>
+    <property name="text_column">0</property>
     <child>
       <object class="GtkCellRendererText"/>
       <attributes>
@@ -313,7 +316,7 @@
   </object>
   <object class="GtkEntryCompletion" id="completion_item_thrown_pierce">
     <property name="model">completion_item_thrown_pierce_store</property>
-    <property name="text-column">0</property>
+    <property name="text_column">0</property>
     <child>
       <object class="GtkCellRendererText"/>
       <attributes>
@@ -329,7 +332,7 @@
   </object>
   <object class="GtkEntryCompletion" id="completion_item_thrown_rock">
     <property name="model">completion_item_thrown_rock_store</property>
-    <property name="text-column">0</property>
+    <property name="text_column">0</property>
     <child>
       <object class="GtkCellRendererText"/>
       <attributes>
@@ -345,7 +348,7 @@
   </object>
   <object class="GtkEntryCompletion" id="completion_item_tms">
     <property name="model">completion_item_tms_store</property>
-    <property name="text-column">0</property>
+    <property name="text_column">0</property>
     <child>
       <object class="GtkCellRendererText"/>
       <attributes>
@@ -361,7 +364,7 @@
   </object>
   <object class="GtkEntryCompletion" id="completion_monsters">
     <property name="model">completion_monsters_store</property>
-    <property name="text-column">0</property>
+    <property name="text_column">0</property>
     <child>
       <object class="GtkCellRendererText"/>
       <attributes>
@@ -396,25 +399,28 @@
     </columns>
   </object>
   <object class="GtkDialog" id="export_dialog">
-    <property name="can-focus">False</property>
+    <property name="can_focus">False</property>
     <property name="title" translatable="yes">Export Dungeon Floor</property>
-    <property name="type-hint">dialog</property>
+    <property name="type_hint">dialog</property>
+    <child type="titlebar">
+      <placeholder/>
+    </child>
     <child internal-child="vbox">
       <object class="GtkBox">
-        <property name="can-focus">False</property>
+        <property name="can_focus">False</property>
         <property name="orientation">vertical</property>
         <property name="spacing">2</property>
         <child internal-child="action_area">
           <object class="GtkButtonBox">
-            <property name="can-focus">False</property>
-            <property name="layout-style">end</property>
+            <property name="can_focus">False</property>
+            <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="button4">
                 <property name="label">gtk-cancel</property>
                 <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="receives-default">True</property>
-                <property name="use-stock">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_stock">True</property>
               </object>
               <packing>
                 <property name="expand">True</property>
@@ -426,9 +432,9 @@
               <object class="GtkButton" id="button3">
                 <property name="label">gtk-save</property>
                 <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="receives-default">True</property>
-                <property name="use-stock">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="use_stock">True</property>
               </object>
               <packing>
                 <property name="expand">True</property>
@@ -446,253 +452,252 @@
         <child>
           <object class="GtkBox">
             <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="margin-start">5</property>
-            <property name="margin-end">5</property>
-            <property name="margin-top">5</property>
-            <property name="margin-bottom">5</property>
+            <property name="can_focus">False</property>
+            <property name="margin_start">5</property>
+            <property name="margin_end">5</property>
+            <property name="margin_top">5</property>
+            <property name="margin_bottom">5</property>
             <property name="orientation">vertical</property>
             <property name="spacing">10</property>
             <child>
               <object class="GtkFrame">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="label-xalign">0</property>
-                <property name="shadow-type">none</property>
+                <property name="can_focus">False</property>
+                <property name="label_xalign">0</property>
+                <property name="shadow_type">none</property>
                 <child>
                   <object class="GtkAlignment">
                     <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="left-padding">12</property>
+                    <property name="can_focus">False</property>
+                    <property name="left_padding">12</property>
                     <child>
-                      <!-- n-columns=4 n-rows=5 -->
                       <object class="GtkGrid">
                         <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="row-spacing">2</property>
-                        <property name="column-spacing">2</property>
+                        <property name="can_focus">False</property>
+                        <property name="row_spacing">2</property>
+                        <property name="column_spacing">2</property>
                         <child>
                           <object class="GtkSwitch" id="export_type_layout">
                             <property name="visible">True</property>
-                            <property name="can-focus">True</property>
+                            <property name="can_focus">True</property>
                             <property name="active">True</property>
                           </object>
                           <packing>
-                            <property name="left-attach">0</property>
-                            <property name="top-attach">0</property>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">0</property>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkSwitch" id="export_type_monsters">
                             <property name="visible">True</property>
-                            <property name="can-focus">True</property>
+                            <property name="can_focus">True</property>
                             <property name="active">True</property>
                           </object>
                           <packing>
-                            <property name="left-attach">2</property>
-                            <property name="top-attach">0</property>
+                            <property name="left_attach">2</property>
+                            <property name="top_attach">0</property>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkSwitch" id="export_type_traps">
                             <property name="visible">True</property>
-                            <property name="can-focus">True</property>
+                            <property name="can_focus">True</property>
                             <property name="active">True</property>
                           </object>
                           <packing>
-                            <property name="left-attach">0</property>
-                            <property name="top-attach">1</property>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">1</property>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkSwitch" id="export_type_floor_items">
                             <property name="visible">True</property>
-                            <property name="can-focus">True</property>
+                            <property name="can_focus">True</property>
                             <property name="active">True</property>
                           </object>
                           <packing>
-                            <property name="left-attach">2</property>
-                            <property name="top-attach">1</property>
+                            <property name="left_attach">2</property>
+                            <property name="top_attach">1</property>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkSwitch" id="export_type_shop_items">
                             <property name="visible">True</property>
-                            <property name="can-focus">True</property>
+                            <property name="can_focus">True</property>
                             <property name="active">True</property>
                           </object>
                           <packing>
-                            <property name="left-attach">0</property>
-                            <property name="top-attach">2</property>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">2</property>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkSwitch" id="export_type_monster_house_items">
                             <property name="visible">True</property>
-                            <property name="can-focus">True</property>
+                            <property name="can_focus">True</property>
                             <property name="active">True</property>
                           </object>
                           <packing>
-                            <property name="left-attach">2</property>
-                            <property name="top-attach">2</property>
+                            <property name="left_attach">2</property>
+                            <property name="top_attach">2</property>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkSwitch" id="export_type_buried_items">
                             <property name="visible">True</property>
-                            <property name="can-focus">True</property>
+                            <property name="can_focus">True</property>
                             <property name="active">True</property>
                           </object>
                           <packing>
-                            <property name="left-attach">0</property>
-                            <property name="top-attach">3</property>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">3</property>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkSwitch" id="export_type_unk_items1">
                             <property name="visible">True</property>
-                            <property name="can-focus">True</property>
+                            <property name="can_focus">True</property>
                             <property name="active">True</property>
                           </object>
                           <packing>
-                            <property name="left-attach">2</property>
-                            <property name="top-attach">3</property>
+                            <property name="left_attach">2</property>
+                            <property name="top_attach">3</property>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkSwitch" id="export_type_unk_items2">
                             <property name="visible">True</property>
-                            <property name="can-focus">True</property>
+                            <property name="can_focus">True</property>
                             <property name="active">True</property>
                           </object>
                           <packing>
-                            <property name="left-attach">0</property>
-                            <property name="top-attach">4</property>
+                            <property name="left_attach">0</property>
+                            <property name="top_attach">4</property>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkLabel">
                             <property name="visible">True</property>
-                            <property name="can-focus">False</property>
+                            <property name="can_focus">False</property>
                             <property name="halign">start</property>
-                            <property name="margin-end">10</property>
+                            <property name="margin_end">10</property>
                             <property name="label" translatable="yes">Layout</property>
                           </object>
                           <packing>
-                            <property name="left-attach">1</property>
-                            <property name="top-attach">0</property>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">0</property>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkLabel">
                             <property name="visible">True</property>
-                            <property name="can-focus">False</property>
+                            <property name="can_focus">False</property>
                             <property name="halign">start</property>
-                            <property name="margin-right">10</property>
-                            <property name="margin-end">10</property>
+                            <property name="margin_right">10</property>
+                            <property name="margin_end">10</property>
                             <property name="label" translatable="yes">Pokémon Spawns</property>
                           </object>
                           <packing>
-                            <property name="left-attach">3</property>
-                            <property name="top-attach">0</property>
+                            <property name="left_attach">3</property>
+                            <property name="top_attach">0</property>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkLabel">
                             <property name="visible">True</property>
-                            <property name="can-focus">False</property>
+                            <property name="can_focus">False</property>
                             <property name="halign">start</property>
-                            <property name="margin-right">10</property>
-                            <property name="margin-end">10</property>
+                            <property name="margin_right">10</property>
+                            <property name="margin_end">10</property>
                             <property name="label" translatable="yes">Trap Spawns</property>
                           </object>
                           <packing>
-                            <property name="left-attach">1</property>
-                            <property name="top-attach">1</property>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">1</property>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkLabel">
                             <property name="visible">True</property>
-                            <property name="can-focus">False</property>
+                            <property name="can_focus">False</property>
                             <property name="halign">start</property>
-                            <property name="margin-right">10</property>
-                            <property name="margin-end">10</property>
+                            <property name="margin_right">10</property>
+                            <property name="margin_end">10</property>
                             <property name="label" translatable="yes">Floor Item Spawns</property>
                           </object>
                           <packing>
-                            <property name="left-attach">3</property>
-                            <property name="top-attach">1</property>
+                            <property name="left_attach">3</property>
+                            <property name="top_attach">1</property>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkLabel">
                             <property name="visible">True</property>
-                            <property name="can-focus">False</property>
+                            <property name="can_focus">False</property>
                             <property name="halign">start</property>
-                            <property name="margin-right">10</property>
-                            <property name="margin-end">10</property>
+                            <property name="margin_right">10</property>
+                            <property name="margin_end">10</property>
                             <property name="label" translatable="yes">Shop Item Spawns</property>
                           </object>
                           <packing>
-                            <property name="left-attach">1</property>
-                            <property name="top-attach">2</property>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">2</property>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkLabel">
                             <property name="visible">True</property>
-                            <property name="can-focus">False</property>
+                            <property name="can_focus">False</property>
                             <property name="halign">start</property>
-                            <property name="margin-right">10</property>
-                            <property name="margin-end">10</property>
+                            <property name="margin_right">10</property>
+                            <property name="margin_end">10</property>
                             <property name="label" translatable="yes">Monster House Item Spawns</property>
                           </object>
                           <packing>
-                            <property name="left-attach">3</property>
-                            <property name="top-attach">2</property>
+                            <property name="left_attach">3</property>
+                            <property name="top_attach">2</property>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkLabel">
                             <property name="visible">True</property>
-                            <property name="can-focus">False</property>
+                            <property name="can_focus">False</property>
                             <property name="halign">start</property>
-                            <property name="margin-right">10</property>
-                            <property name="margin-end">10</property>
+                            <property name="margin_right">10</property>
+                            <property name="margin_end">10</property>
                             <property name="label" translatable="yes">Bruied Item Spawns</property>
                           </object>
                           <packing>
-                            <property name="left-attach">1</property>
-                            <property name="top-attach">3</property>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">3</property>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkLabel">
                             <property name="visible">True</property>
-                            <property name="can-focus">False</property>
+                            <property name="can_focus">False</property>
                             <property name="halign">start</property>
-                            <property name="margin-right">10</property>
-                            <property name="margin-end">10</property>
+                            <property name="margin_right">10</property>
+                            <property name="margin_end">10</property>
                             <property name="label" translatable="yes">Unk1 Item Spawns</property>
                           </object>
                           <packing>
-                            <property name="left-attach">3</property>
-                            <property name="top-attach">3</property>
+                            <property name="left_attach">3</property>
+                            <property name="top_attach">3</property>
                           </packing>
                         </child>
                         <child>
                           <object class="GtkLabel">
                             <property name="visible">True</property>
-                            <property name="can-focus">False</property>
+                            <property name="can_focus">False</property>
                             <property name="halign">start</property>
-                            <property name="margin-right">10</property>
-                            <property name="margin-end">10</property>
+                            <property name="margin_right">10</property>
+                            <property name="margin_end">10</property>
                             <property name="label" translatable="yes">Unk2 Item Spawns</property>
                           </object>
                           <packing>
-                            <property name="left-attach">1</property>
-                            <property name="top-attach">4</property>
+                            <property name="left_attach">1</property>
+                            <property name="top_attach">4</property>
                           </packing>
                         </child>
                         <child>
@@ -708,9 +713,9 @@
                 <child type="label">
                   <object class="GtkLabel">
                     <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="margin-top">5</property>
-                    <property name="margin-bottom">5</property>
+                    <property name="can_focus">False</property>
+                    <property name="margin_top">5</property>
+                    <property name="margin_bottom">5</property>
                     <property name="label" translatable="yes">1. Choose what to export</property>
                     <attributes>
                       <attribute name="weight" value="bold"/>
@@ -727,27 +732,27 @@
             <child>
               <object class="GtkBox">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkFrame">
                     <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="label-xalign">0</property>
-                    <property name="shadow-type">none</property>
+                    <property name="can_focus">False</property>
+                    <property name="label_xalign">0</property>
+                    <property name="shadow_type">none</property>
                     <child>
                       <object class="GtkAlignment">
                         <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="left-padding">12</property>
+                        <property name="can_focus">False</property>
+                        <property name="left_padding">12</property>
                         <child>
                           <object class="GtkBox">
                             <property name="visible">True</property>
-                            <property name="can-focus">False</property>
+                            <property name="can_focus">False</property>
                             <child>
                               <object class="GtkSwitch" id="export_file_switch">
                                 <property name="visible">True</property>
-                                <property name="can-focus">True</property>
+                                <property name="can_focus">True</property>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -758,7 +763,7 @@
                             <child>
                               <object class="GtkLabel">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
+                                <property name="can_focus">False</property>
                                 <property name="label" translatable="yes"> Export to file</property>
                               </object>
                               <packing>
@@ -774,9 +779,9 @@
                     <child type="label">
                       <object class="GtkLabel">
                         <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="margin-top">5</property>
-                        <property name="margin-bottom">5</property>
+                        <property name="can_focus">False</property>
+                        <property name="margin_top">5</property>
+                        <property name="margin_bottom">5</property>
                         <property name="label" translatable="yes">2a. Export to file</property>
                         <attributes>
                           <attribute name="weight" value="bold"/>
@@ -793,25 +798,25 @@
                 <child>
                   <object class="GtkFrame">
                     <property name="visible">True</property>
-                    <property name="can-focus">False</property>
+                    <property name="can_focus">False</property>
                     <property name="vexpand">True</property>
-                    <property name="label-xalign">0</property>
-                    <property name="shadow-type">none</property>
+                    <property name="label_xalign">0</property>
+                    <property name="shadow_type">none</property>
                     <child>
                       <object class="GtkAlignment">
                         <property name="visible">True</property>
-                        <property name="can-focus">False</property>
+                        <property name="can_focus">False</property>
                         <property name="vexpand">True</property>
-                        <property name="left-padding">12</property>
+                        <property name="left_padding">12</property>
                         <child>
                           <object class="GtkScrolledWindow">
                             <property name="visible">True</property>
-                            <property name="can-focus">True</property>
-                            <property name="shadow-type">in</property>
+                            <property name="can_focus">True</property>
+                            <property name="shadow_type">in</property>
                             <child>
                               <object class="GtkTreeView">
                                 <property name="visible">True</property>
-                                <property name="can-focus">True</property>
+                                <property name="can_focus">True</property>
                                 <property name="vexpand">True</property>
                                 <property name="model">export_dialog_store</property>
                                 <child internal-child="selection">
@@ -857,11 +862,11 @@
                     <child type="label">
                       <object class="GtkLabel">
                         <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="margin-top">5</property>
-                        <property name="margin-bottom">5</property>
+                        <property name="can_focus">False</property>
+                        <property name="margin_top">5</property>
+                        <property name="margin_bottom">5</property>
                         <property name="label" translatable="yes">(and/or) &lt;b&gt;2b. Copy to other floor(s)&lt;/b&gt;</property>
-                        <property name="use-markup">True</property>
+                        <property name="use_markup">True</property>
                       </object>
                     </child>
                   </object>
@@ -1030,7 +1035,7 @@
   </object>
   <object class="GtkLabel" id="monster_spawns_chance_label">
     <property name="visible">True</property>
-    <property name="can-focus">False</property>
+    <property name="can_focus">False</property>
     <property name="label" translatable="yes">Chance</property>
     <attributes>
       <attribute name="style" value="italic"/>
@@ -1067,7 +1072,7 @@
   </object>
   <object class="GtkLabel" id="trap_spawns_tree_chance_label">
     <property name="visible">True</property>
-    <property name="can-focus">False</property>
+    <property name="can_focus">False</property>
     <property name="label" translatable="yes">Chance</property>
     <attributes>
       <attribute name="style" value="italic"/>
@@ -1076,128 +1081,127 @@
   </object>
   <object class="GtkBox" id="box_editor">
     <property name="visible">True</property>
-    <property name="can-focus">False</property>
+    <property name="can_focus">False</property>
     <property name="spacing">5</property>
     <child>
-      <!-- n-columns=3 n-rows=10 -->
       <object class="GtkGrid">
         <property name="visible">True</property>
-        <property name="can-focus">False</property>
-        <property name="margin-start">10</property>
-        <property name="margin-end">5</property>
-        <property name="margin-top">5</property>
-        <property name="margin-bottom">5</property>
-        <property name="row-spacing">5</property>
-        <property name="column-spacing">5</property>
+        <property name="can_focus">False</property>
+        <property name="margin_start">10</property>
+        <property name="margin_end">5</property>
+        <property name="margin_top">5</property>
+        <property name="margin_bottom">5</property>
+        <property name="row_spacing">5</property>
+        <property name="column_spacing">5</property>
         <child>
           <object class="GtkLabel" id="label_dungeon_name">
             <property name="visible">True</property>
-            <property name="can-focus">False</property>
+            <property name="can_focus">False</property>
             <property name="label" translatable="yes">Dungeon Name</property>
             <property name="justify">center</property>
           </object>
           <packing>
-            <property name="left-attach">1</property>
-            <property name="top-attach">0</property>
+            <property name="left_attach">1</property>
+            <property name="top_attach">0</property>
             <property name="width">2</property>
           </packing>
         </child>
         <child>
           <object class="GtkLabel" id="label_floor_number">
             <property name="visible">True</property>
-            <property name="can-focus">False</property>
+            <property name="can_focus">False</property>
             <property name="label" translatable="yes">Floor Number</property>
           </object>
           <packing>
-            <property name="left-attach">1</property>
-            <property name="top-attach">1</property>
+            <property name="left_attach">1</property>
+            <property name="top_attach">1</property>
             <property name="width">2</property>
           </packing>
         </child>
         <child>
           <object class="GtkLabel">
             <property name="visible">True</property>
-            <property name="can-focus">False</property>
+            <property name="can_focus">False</property>
           </object>
           <packing>
-            <property name="left-attach">0</property>
-            <property name="top-attach">3</property>
+            <property name="left_attach">0</property>
+            <property name="top_attach">3</property>
             <property name="width">3</property>
           </packing>
         </child>
         <child>
           <object class="GtkLabel">
             <property name="visible">True</property>
-            <property name="can-focus">False</property>
+            <property name="can_focus">False</property>
             <property name="label" translatable="yes">Tileset</property>
           </object>
           <packing>
-            <property name="left-attach">0</property>
-            <property name="top-attach">4</property>
+            <property name="left_attach">0</property>
+            <property name="top_attach">4</property>
           </packing>
         </child>
         <child>
           <object class="GtkLabel">
             <property name="visible">True</property>
-            <property name="can-focus">False</property>
+            <property name="can_focus">False</property>
             <property name="label" translatable="yes">Music</property>
           </object>
           <packing>
-            <property name="left-attach">0</property>
-            <property name="top-attach">6</property>
+            <property name="left_attach">0</property>
+            <property name="top_attach">6</property>
           </packing>
         </child>
         <child>
           <object class="GtkLabel">
             <property name="visible">True</property>
-            <property name="can-focus">False</property>
+            <property name="can_focus">False</property>
             <property name="label" translatable="yes">Fixed Room</property>
           </object>
           <packing>
-            <property name="left-attach">0</property>
-            <property name="top-attach">7</property>
+            <property name="left_attach">0</property>
+            <property name="top_attach">7</property>
           </packing>
         </child>
         <child>
           <object class="GtkComboBox" id="cb_tileset_id">
             <property name="visible">True</property>
-            <property name="can-focus">False</property>
+            <property name="can_focus">False</property>
             <signal name="changed" handler="on_cb_tileset_id_changed" swapped="no"/>
           </object>
           <packing>
-            <property name="left-attach">1</property>
-            <property name="top-attach">4</property>
+            <property name="left_attach">1</property>
+            <property name="top_attach">4</property>
             <property name="width">2</property>
           </packing>
         </child>
         <child>
           <object class="GtkComboBox" id="cb_music_id">
             <property name="visible">True</property>
-            <property name="can-focus">False</property>
+            <property name="can_focus">False</property>
             <signal name="changed" handler="on_cb_music_id_changed" swapped="no"/>
           </object>
           <packing>
-            <property name="left-attach">1</property>
-            <property name="top-attach">6</property>
+            <property name="left_attach">1</property>
+            <property name="top_attach">6</property>
             <property name="width">2</property>
           </packing>
         </child>
         <child>
           <object class="GtkComboBox" id="cb_fixed_floor_id">
             <property name="visible">True</property>
-            <property name="can-focus">False</property>
+            <property name="can_focus">False</property>
             <signal name="changed" handler="on_cb_fixed_floor_id_changed" swapped="no"/>
           </object>
           <packing>
-            <property name="left-attach">1</property>
-            <property name="top-attach">7</property>
+            <property name="left_attach">1</property>
+            <property name="top_attach">7</property>
             <property name="width">2</property>
           </packing>
         </child>
         <child>
           <object class="GtkBox">
             <property name="visible">True</property>
-            <property name="can-focus">False</property>
+            <property name="can_focus">False</property>
             <property name="halign">center</property>
             <property name="valign">end</property>
             <property name="vexpand">True</property>
@@ -1205,20 +1209,20 @@
             <child>
               <object class="GtkButton" id="btn_import">
                 <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="receives-default">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
                 <signal name="clicked" handler="on_btn_import_clicked" swapped="no"/>
                 <child>
                   <object class="GtkBox">
                     <property name="visible">True</property>
-                    <property name="can-focus">False</property>
+                    <property name="can_focus">False</property>
                     <property name="orientation">vertical</property>
                     <property name="spacing">5</property>
                     <child>
                       <object class="GtkImage">
                         <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="icon-name">skytemple-import-symbolic</property>
+                        <property name="can_focus">False</property>
+                        <property name="icon_name">skytemple-import-symbolic</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -1229,7 +1233,7 @@
                     <child>
                       <object class="GtkLabel">
                         <property name="visible">True</property>
-                        <property name="can-focus">False</property>
+                        <property name="can_focus">False</property>
                         <property name="label" translatable="yes">Import</property>
                       </object>
                       <packing>
@@ -1250,20 +1254,20 @@
             <child>
               <object class="GtkButton" id="btn_export">
                 <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="receives-default">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
                 <signal name="clicked" handler="on_btn_export_clicked" swapped="no"/>
                 <child>
                   <object class="GtkBox">
                     <property name="visible">True</property>
-                    <property name="can-focus">False</property>
+                    <property name="can_focus">False</property>
                     <property name="orientation">vertical</property>
                     <property name="spacing">5</property>
                     <child>
                       <object class="GtkImage">
                         <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="icon-name">skytemple-export-symbolic</property>
+                        <property name="can_focus">False</property>
+                        <property name="icon_name">skytemple-export-symbolic</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -1274,7 +1278,7 @@
                     <child>
                       <object class="GtkLabel">
                         <property name="visible">True</property>
-                        <property name="can-focus">False</property>
+                        <property name="can_focus">False</property>
                         <property name="label" translatable="yes">Export</property>
                       </object>
                       <packing>
@@ -1294,38 +1298,38 @@
             </child>
           </object>
           <packing>
-            <property name="left-attach">0</property>
-            <property name="top-attach">9</property>
+            <property name="left_attach">0</property>
+            <property name="top_attach">9</property>
             <property name="width">3</property>
           </packing>
         </child>
         <child>
           <object class="GtkDrawingArea" id="draw_mini_preview">
             <property name="visible">True</property>
-            <property name="can-focus">False</property>
+            <property name="can_focus">False</property>
           </object>
           <packing>
-            <property name="left-attach">0</property>
-            <property name="top-attach">0</property>
+            <property name="left_attach">0</property>
+            <property name="top_attach">0</property>
             <property name="height">3</property>
           </packing>
         </child>
         <child>
           <object class="GtkButton" id="btn_goto_tileset">
             <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="receives-default">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
             <property name="valign">center</property>
             <signal name="clicked" handler="on_btn_goto_tileset_clicked" swapped="no"/>
             <child>
               <object class="GtkBox">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="spacing">5</property>
                 <child>
                   <object class="GtkLabel">
                     <property name="visible">True</property>
-                    <property name="can-focus">False</property>
+                    <property name="can_focus">False</property>
                     <property name="label" translatable="yes">Go To</property>
                   </object>
                   <packing>
@@ -1337,8 +1341,8 @@
                 <child>
                   <object class="GtkImage">
                     <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="icon-name">skytemple-go-next-symbolic</property>
+                    <property name="can_focus">False</property>
+                    <property name="icon_name">skytemple-go-next-symbolic</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -1350,27 +1354,27 @@
             </child>
           </object>
           <packing>
-            <property name="left-attach">1</property>
-            <property name="top-attach">5</property>
+            <property name="left_attach">1</property>
+            <property name="top_attach">5</property>
             <property name="width">2</property>
           </packing>
         </child>
         <child>
           <object class="GtkButton" id="btn_goto_fixed_floor">
             <property name="visible">True</property>
-            <property name="can-focus">True</property>
-            <property name="receives-default">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
             <property name="valign">center</property>
             <signal name="clicked" handler="on_btn_goto_fixed_floor_clicked" swapped="no"/>
             <child>
               <object class="GtkBox">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="spacing">5</property>
                 <child>
                   <object class="GtkLabel">
                     <property name="visible">True</property>
-                    <property name="can-focus">False</property>
+                    <property name="can_focus">False</property>
                     <property name="label" translatable="yes">Go To</property>
                   </object>
                   <packing>
@@ -1382,8 +1386,8 @@
                 <child>
                   <object class="GtkImage">
                     <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="icon-name">skytemple-go-next-symbolic</property>
+                    <property name="can_focus">False</property>
+                    <property name="icon_name">skytemple-go-next-symbolic</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -1395,29 +1399,29 @@
             </child>
           </object>
           <packing>
-            <property name="left-attach">1</property>
-            <property name="top-attach">8</property>
+            <property name="left_attach">1</property>
+            <property name="top_attach">8</property>
             <property name="width">2</property>
           </packing>
         </child>
         <child>
           <object class="GtkLabel">
             <property name="visible">True</property>
-            <property name="can-focus">False</property>
+            <property name="can_focus">False</property>
           </object>
           <packing>
-            <property name="left-attach">0</property>
-            <property name="top-attach">5</property>
+            <property name="left_attach">0</property>
+            <property name="top_attach">5</property>
           </packing>
         </child>
         <child>
           <object class="GtkLabel">
             <property name="visible">True</property>
-            <property name="can-focus">False</property>
+            <property name="can_focus">False</property>
           </object>
           <packing>
-            <property name="left-attach">0</property>
-            <property name="top-attach">8</property>
+            <property name="left_attach">0</property>
+            <property name="top_attach">8</property>
           </packing>
         </child>
         <child>
@@ -1440,23 +1444,24 @@
     <child>
       <object class="GtkNotebook" id="floor_notebook">
         <property name="visible">True</property>
-        <property name="can-focus">True</property>
+        <property name="can_focus">True</property>
         <signal name="switch-page" handler="on_floor_notebook_switch_page" swapped="no"/>
         <child>
-          <!-- n-columns=6 n-rows=21 -->
           <object class="GtkGrid" id="layout_grid">
             <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="margin-start">10</property>
-            <property name="margin-end">5</property>
-            <property name="margin-top">5</property>
-            <property name="margin-bottom">5</property>
-            <property name="row-spacing">5</property>
-            <property name="column-spacing">5</property>
+            <property name="can_focus">False</property>
+            <property name="margin_left">10</property>
+            <property name="margin_right">5</property>
+            <property name="margin_start">10</property>
+            <property name="margin_end">5</property>
+            <property name="margin_top">5</property>
+            <property name="margin_bottom">5</property>
+            <property name="row_spacing">5</property>
+            <property name="column_spacing">5</property>
             <child>
               <object class="GtkLabel">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="halign">start</property>
                 <property name="label" translatable="yes">Structure</property>
                 <attributes>
@@ -1464,653 +1469,641 @@
                 </attributes>
               </object>
               <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">0</property>
+                <property name="left_attach">0</property>
+                <property name="top_attach">0</property>
                 <property name="width">6</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="label" translatable="yes">Structure Type:</property>
               </object>
               <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">1</property>
+                <property name="left_attach">0</property>
+                <property name="top_attach">1</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="label" translatable="yes">Floor connectivity:</property>
               </object>
               <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">2</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="halign">end</property>
-                <property name="label" translatable="yes">Room Density:</property>
-              </object>
-              <packing>
-                <property name="left-attach">3</property>
-                <property name="top-attach">1</property>
+                <property name="left_attach">0</property>
+                <property name="top_attach">2</property>
               </packing>
             </child>
             <child>
               <object class="GtkEntry" id="entry_room_density">
                 <property name="visible">True</property>
-                <property name="can-focus">True</property>
+                <property name="can_focus">True</property>
                 <signal name="changed" handler="on_entry_room_density_changed" swapped="no"/>
               </object>
               <packing>
-                <property name="left-attach">4</property>
-                <property name="top-attach">1</property>
+                <property name="left_attach">4</property>
+                <property name="top_attach">1</property>
               </packing>
             </child>
             <child>
               <object class="GtkComboBox" id="cb_structure">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <signal name="changed" handler="on_cb_structure_changed" swapped="no"/>
               </object>
               <packing>
-                <property name="left-attach">1</property>
-                <property name="top-attach">1</property>
+                <property name="left_attach">1</property>
+                <property name="top_attach">1</property>
                 <property name="width">2</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="label" translatable="yes">Dead Ends?:</property>
               </object>
               <packing>
-                <property name="left-attach">3</property>
-                <property name="top-attach">2</property>
+                <property name="left_attach">3</property>
+                <property name="top_attach">2</property>
               </packing>
             </child>
             <child>
               <object class="GtkEntry" id="entry_floor_connectivity">
                 <property name="visible">True</property>
-                <property name="can-focus">True</property>
+                <property name="can_focus">True</property>
                 <signal name="changed" handler="on_entry_floor_connectivity_changed" swapped="no"/>
               </object>
               <packing>
-                <property name="left-attach">1</property>
-                <property name="top-attach">2</property>
+                <property name="left_attach">1</property>
+                <property name="top_attach">2</property>
               </packing>
             </child>
             <child>
               <object class="GtkButton" id="btn_help_floor_connectivity">
                 <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="receives-default">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
                 <property name="halign">start</property>
                 <property name="valign">center</property>
                 <signal name="clicked" handler="on_btn_help_floor_connectivity_clicked" swapped="no"/>
                 <child>
                   <object class="GtkImage">
                     <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="icon-name">skytemple-help-about-symbolic</property>
+                    <property name="can_focus">False</property>
+                    <property name="icon_name">skytemple-help-about-symbolic</property>
                   </object>
                 </child>
               </object>
               <packing>
-                <property name="left-attach">2</property>
-                <property name="top-attach">2</property>
+                <property name="left_attach">2</property>
+                <property name="top_attach">2</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="label" translatable="yes">Extra Hallway density:</property>
               </object>
               <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">3</property>
+                <property name="left_attach">0</property>
+                <property name="top_attach">3</property>
               </packing>
             </child>
             <child>
               <object class="GtkEntry" id="entry_extra_hallway_density">
                 <property name="visible">True</property>
-                <property name="can-focus">True</property>
+                <property name="can_focus">True</property>
                 <signal name="changed" handler="on_entry_extra_hallway_density_changed" swapped="no"/>
               </object>
               <packing>
-                <property name="left-attach">1</property>
-                <property name="top-attach">3</property>
+                <property name="left_attach">1</property>
+                <property name="top_attach">3</property>
               </packing>
             </child>
             <child>
               <object class="GtkButton" id="btn_help_extra_hallway_density">
                 <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="receives-default">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
                 <property name="halign">start</property>
                 <property name="valign">center</property>
                 <signal name="clicked" handler="on_btn_help_extra_hallway_density_clicked" swapped="no"/>
                 <child>
                   <object class="GtkImage">
                     <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="icon-name">skytemple-help-about-symbolic</property>
+                    <property name="can_focus">False</property>
+                    <property name="icon_name">skytemple-help-about-symbolic</property>
                   </object>
                 </child>
               </object>
               <packing>
-                <property name="left-attach">2</property>
-                <property name="top-attach">3</property>
+                <property name="left_attach">2</property>
+                <property name="top_attach">3</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="halign">end</property>
               </object>
               <packing>
-                <property name="left-attach">3</property>
-                <property name="top-attach">3</property>
+                <property name="left_attach">3</property>
+                <property name="top_attach">3</property>
                 <property name="width">3</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="halign">start</property>
-                <property name="margin-top">5</property>
+                <property name="margin_top">5</property>
                 <property name="label" translatable="yes">Terrain Settings</property>
                 <attributes>
                   <attribute name="weight" value="bold"/>
                 </attributes>
               </object>
               <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">4</property>
+                <property name="left_attach">0</property>
+                <property name="top_attach">4</property>
                 <property name="width">6</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="label" translatable="yes">Secondary T. enabled?:</property>
               </object>
               <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">5</property>
+                <property name="left_attach">0</property>
+                <property name="top_attach">5</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="label" translatable="yes">Secondary Terrain:</property>
               </object>
               <packing>
-                <property name="left-attach">3</property>
-                <property name="top-attach">5</property>
+                <property name="left_attach">3</property>
+                <property name="top_attach">5</property>
               </packing>
             </child>
             <child>
               <object class="GtkComboBox" id="cb_secondary_terrain">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <signal name="changed" handler="on_cb_secondary_terrain_changed" swapped="no"/>
               </object>
               <packing>
-                <property name="left-attach">4</property>
-                <property name="top-attach">5</property>
+                <property name="left_attach">4</property>
+                <property name="top_attach">5</property>
                 <property name="width">2</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="label" translatable="yes">Secondary T. density:</property>
               </object>
               <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">6</property>
+                <property name="left_attach">0</property>
+                <property name="top_attach">6</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="label" translatable="yes">Imperfect rooms?:</property>
               </object>
               <packing>
-                <property name="left-attach">3</property>
-                <property name="top-attach">6</property>
+                <property name="left_attach">3</property>
+                <property name="top_attach">6</property>
               </packing>
             </child>
             <child>
               <object class="GtkEntry" id="entry_water_density">
                 <property name="visible">True</property>
-                <property name="can-focus">True</property>
+                <property name="can_focus">True</property>
                 <signal name="changed" handler="on_entry_water_density_changed" swapped="no"/>
               </object>
               <packing>
-                <property name="left-attach">1</property>
-                <property name="top-attach">6</property>
+                <property name="left_attach">1</property>
+                <property name="top_attach">6</property>
               </packing>
             </child>
             <child>
               <object class="GtkButton" id="btn_help_water_density">
                 <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="receives-default">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
                 <property name="halign">start</property>
                 <property name="valign">center</property>
                 <signal name="clicked" handler="on_btn_help_water_density_clicked" swapped="no"/>
                 <child>
                   <object class="GtkImage">
                     <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="icon-name">skytemple-help-about-symbolic</property>
+                    <property name="can_focus">False</property>
+                    <property name="icon_name">skytemple-help-about-symbolic</property>
                   </object>
                 </child>
               </object>
               <packing>
-                <property name="left-attach">2</property>
-                <property name="top-attach">6</property>
+                <property name="left_attach">2</property>
+                <property name="top_attach">6</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="halign">start</property>
-                <property name="margin-top">5</property>
+                <property name="margin_top">5</property>
                 <property name="label" translatable="yes">Weather and Conditions</property>
                 <attributes>
                   <attribute name="weight" value="bold"/>
                 </attributes>
               </object>
               <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">7</property>
+                <property name="left_attach">0</property>
+                <property name="top_attach">7</property>
                 <property name="width">6</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="label" translatable="yes">Darkness Level:</property>
               </object>
               <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">8</property>
+                <property name="left_attach">0</property>
+                <property name="top_attach">8</property>
               </packing>
             </child>
             <child>
               <object class="GtkComboBox" id="cb_darkness_level">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <signal name="changed" handler="on_cb_darkness_level_changed" swapped="no"/>
               </object>
               <packing>
-                <property name="left-attach">1</property>
-                <property name="top-attach">8</property>
+                <property name="left_attach">1</property>
+                <property name="top_attach">8</property>
                 <property name="width">2</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="label" translatable="yes">Weather:</property>
               </object>
               <packing>
-                <property name="left-attach">3</property>
-                <property name="top-attach">8</property>
+                <property name="left_attach">3</property>
+                <property name="top_attach">8</property>
               </packing>
             </child>
             <child>
               <object class="GtkComboBox" id="cb_weather">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <signal name="changed" handler="on_cb_weather_changed" swapped="no"/>
               </object>
               <packing>
-                <property name="left-attach">4</property>
-                <property name="top-attach">8</property>
+                <property name="left_attach">4</property>
+                <property name="top_attach">8</property>
                 <property name="width">2</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="halign">start</property>
-                <property name="margin-top">5</property>
+                <property name="margin_top">5</property>
                 <property name="label" translatable="yes">Items, Traps and Enemies</property>
                 <attributes>
                   <attribute name="weight" value="bold"/>
                 </attributes>
               </object>
               <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">9</property>
+                <property name="left_attach">0</property>
+                <property name="top_attach">9</property>
                 <property name="width">6</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="label" translatable="yes">Floor item density:</property>
               </object>
               <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">10</property>
+                <property name="left_attach">0</property>
+                <property name="top_attach">10</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="label" translatable="yes">Buried item density:</property>
               </object>
               <packing>
-                <property name="left-attach">3</property>
-                <property name="top-attach">10</property>
+                <property name="left_attach">3</property>
+                <property name="top_attach">10</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="label" translatable="yes">Trap density:</property>
               </object>
               <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">11</property>
+                <property name="left_attach">0</property>
+                <property name="top_attach">11</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="label" translatable="yes">Max coin amount:</property>
               </object>
               <packing>
-                <property name="left-attach">3</property>
-                <property name="top-attach">11</property>
+                <property name="left_attach">3</property>
+                <property name="top_attach">11</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="label" translatable="yes">Initial enemy density:</property>
               </object>
               <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">12</property>
+                <property name="left_attach">0</property>
+                <property name="top_attach">12</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="label" translatable="yes">Kecleon Shop:</property>
               </object>
               <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">14</property>
+                <property name="left_attach">0</property>
+                <property name="top_attach">14</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="label" translatable="yes">Monster House:</property>
               </object>
               <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">15</property>
+                <property name="left_attach">0</property>
+                <property name="top_attach">15</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="label" translatable="yes">Unusued:</property>
               </object>
               <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">16</property>
+                <property name="left_attach">0</property>
+                <property name="top_attach">16</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="label" translatable="yes">Empty Monster House:</property>
               </object>
               <packing>
-                <property name="left-attach">3</property>
-                <property name="top-attach">15</property>
+                <property name="left_attach">3</property>
+                <property name="top_attach">15</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="label" translatable="yes">Sticky Items:</property>
               </object>
               <packing>
-                <property name="left-attach">3</property>
-                <property name="top-attach">16</property>
+                <property name="left_attach">3</property>
+                <property name="top_attach">16</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="halign">start</property>
-                <property name="margin-top">5</property>
+                <property name="margin_top">5</property>
                 <property name="label" translatable="yes">IQ and Misc</property>
                 <attributes>
                   <attribute name="weight" value="bold"/>
                 </attributes>
               </object>
               <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">17</property>
+                <property name="left_attach">0</property>
+                <property name="top_attach">17</property>
                 <property name="width">6</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="label" translatable="yes">Unknown E:</property>
               </object>
               <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">18</property>
+                <property name="left_attach">0</property>
+                <property name="top_attach">18</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="label" translatable="yes">Enemy IQ:</property>
               </object>
               <packing>
-                <property name="left-attach">3</property>
-                <property name="top-attach">18</property>
+                <property name="left_attach">3</property>
+                <property name="top_attach">18</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="label" translatable="yes">IQ Booster enabled?:</property>
               </object>
               <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">19</property>
+                <property name="left_attach">0</property>
+                <property name="top_attach">19</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="halign">end</property>
               </object>
               <packing>
-                <property name="left-attach">3</property>
-                <property name="top-attach">12</property>
+                <property name="left_attach">3</property>
+                <property name="top_attach">12</property>
                 <property name="width">3</property>
               </packing>
             </child>
             <child>
               <object class="GtkEntry" id="entry_item_density">
                 <property name="visible">True</property>
-                <property name="can-focus">True</property>
+                <property name="can_focus">True</property>
                 <signal name="changed" handler="on_entry_item_density_changed" swapped="no"/>
               </object>
               <packing>
-                <property name="left-attach">1</property>
-                <property name="top-attach">10</property>
+                <property name="left_attach">1</property>
+                <property name="top_attach">10</property>
               </packing>
             </child>
             <child>
               <object class="GtkEntry" id="entry_trap_density">
                 <property name="visible">True</property>
-                <property name="can-focus">True</property>
+                <property name="can_focus">True</property>
                 <signal name="changed" handler="on_entry_trap_density_changed" swapped="no"/>
               </object>
               <packing>
-                <property name="left-attach">1</property>
-                <property name="top-attach">11</property>
+                <property name="left_attach">1</property>
+                <property name="top_attach">11</property>
               </packing>
             </child>
             <child>
               <object class="GtkEntry" id="entry_initial_enemy_density">
                 <property name="visible">True</property>
-                <property name="can-focus">True</property>
+                <property name="can_focus">True</property>
                 <signal name="changed" handler="on_entry_initial_enemy_density_changed" swapped="no"/>
               </object>
               <packing>
-                <property name="left-attach">1</property>
-                <property name="top-attach">12</property>
+                <property name="left_attach">1</property>
+                <property name="top_attach">12</property>
               </packing>
             </child>
             <child>
               <object class="GtkEntry" id="entry_buried_item_density">
                 <property name="visible">True</property>
-                <property name="can-focus">True</property>
+                <property name="can_focus">True</property>
                 <signal name="changed" handler="on_entry_buried_item_density_changed" swapped="no"/>
               </object>
               <packing>
-                <property name="left-attach">4</property>
-                <property name="top-attach">10</property>
+                <property name="left_attach">4</property>
+                <property name="top_attach">10</property>
               </packing>
             </child>
             <child>
               <object class="GtkEntry" id="entry_max_coin_amount">
                 <property name="visible">True</property>
-                <property name="can-focus">True</property>
+                <property name="can_focus">True</property>
                 <signal name="changed" handler="on_entry_max_coin_amount_changed" swapped="no"/>
               </object>
               <packing>
-                <property name="left-attach">4</property>
-                <property name="top-attach">11</property>
+                <property name="left_attach">4</property>
+                <property name="top_attach">11</property>
               </packing>
             </child>
             <child>
               <object class="GtkButton" id="btn_help_trap_density">
                 <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="receives-default">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
                 <property name="halign">start</property>
                 <property name="valign">center</property>
                 <signal name="clicked" handler="on_btn_help_trap_density_clicked" swapped="no"/>
                 <child>
                   <object class="GtkImage">
                     <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="icon-name">skytemple-help-about-symbolic</property>
+                    <property name="can_focus">False</property>
+                    <property name="icon_name">skytemple-help-about-symbolic</property>
                   </object>
                 </child>
               </object>
               <packing>
-                <property name="left-attach">2</property>
-                <property name="top-attach">11</property>
+                <property name="left_attach">2</property>
+                <property name="top_attach">11</property>
               </packing>
             </child>
             <child>
               <object class="GtkButton" id="btn_help_max_coin_amount">
                 <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="receives-default">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
                 <property name="halign">start</property>
                 <property name="valign">center</property>
                 <signal name="clicked" handler="on_btn_help_max_coin_amount_clicked" swapped="no"/>
                 <child>
                   <object class="GtkImage">
                     <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="icon-name">skytemple-help-about-symbolic</property>
+                    <property name="can_focus">False</property>
+                    <property name="icon_name">skytemple-help-about-symbolic</property>
                   </object>
                 </child>
               </object>
               <packing>
-                <property name="left-attach">5</property>
-                <property name="top-attach">11</property>
+                <property name="left_attach">5</property>
+                <property name="top_attach">11</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="margin-top">5</property>
+                <property name="can_focus">False</property>
+                <property name="margin_top">5</property>
                 <property name="spacing">10</property>
                 <child>
                   <object class="GtkLabel">
                     <property name="visible">True</property>
-                    <property name="can-focus">False</property>
+                    <property name="can_focus">False</property>
                     <property name="halign">start</property>
                     <property name="label" translatable="yes">Chances</property>
                     <attributes>
@@ -2126,16 +2119,16 @@
                 <child>
                   <object class="GtkButton" id="btn_help_chances">
                     <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="receives-default">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">True</property>
                     <property name="halign">start</property>
                     <property name="valign">center</property>
                     <signal name="clicked" handler="on_btn_help_chances_clicked" swapped="no"/>
                     <child>
                       <object class="GtkImage">
                         <property name="visible">True</property>
-                        <property name="can-focus">False</property>
-                        <property name="icon-name">skytemple-help-about-symbolic</property>
+                        <property name="can_focus">False</property>
+                        <property name="icon_name">skytemple-help-about-symbolic</property>
                       </object>
                     </child>
                   </object>
@@ -2147,391 +2140,489 @@
                 </child>
               </object>
               <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">13</property>
+                <property name="left_attach">0</property>
+                <property name="top_attach">13</property>
                 <property name="width">6</property>
               </packing>
             </child>
             <child>
               <object class="GtkButton" id="btn_help_iq_booster_enabled">
                 <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="receives-default">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
                 <property name="halign">start</property>
                 <property name="valign">center</property>
                 <signal name="clicked" handler="on_btn_help_iq_booster_enabled_clicked" swapped="no"/>
                 <child>
                   <object class="GtkImage">
                     <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="icon-name">skytemple-help-about-symbolic</property>
+                    <property name="can_focus">False</property>
+                    <property name="icon_name">skytemple-help-about-symbolic</property>
                   </object>
                 </child>
               </object>
               <packing>
-                <property name="left-attach">2</property>
-                <property name="top-attach">19</property>
+                <property name="left_attach">2</property>
+                <property name="top_attach">19</property>
               </packing>
             </child>
             <child>
               <object class="GtkEntry" id="entry_enemy_iq">
                 <property name="visible">True</property>
-                <property name="can-focus">True</property>
+                <property name="can_focus">True</property>
                 <signal name="changed" handler="on_entry_enemy_iq_changed" swapped="no"/>
               </object>
               <packing>
-                <property name="left-attach">4</property>
-                <property name="top-attach">18</property>
+                <property name="left_attach">4</property>
+                <property name="top_attach">18</property>
               </packing>
             </child>
             <child>
               <object class="GtkComboBox" id="cb_iq_booster_enabled">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <signal name="changed" handler="on_cb_iq_booster_enabled_changed" swapped="no"/>
               </object>
               <packing>
-                <property name="left-attach">1</property>
-                <property name="top-attach">19</property>
+                <property name="left_attach">1</property>
+                <property name="top_attach">19</property>
               </packing>
             </child>
             <child>
               <object class="GtkComboBox" id="cb_unk_e">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <signal name="changed" handler="on_cb_unk_e_changed" swapped="no"/>
               </object>
               <packing>
-                <property name="left-attach">1</property>
-                <property name="top-attach">18</property>
+                <property name="left_attach">1</property>
+                <property name="top_attach">18</property>
                 <property name="width">2</property>
               </packing>
             </child>
             <child>
               <object class="GtkComboBox" id="cb_terrain_settings__generate_imperfect_rooms">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <signal name="changed" handler="on_cb_terrain_settings__generate_imperfect_rooms_changed" swapped="no"/>
               </object>
               <packing>
-                <property name="left-attach">4</property>
-                <property name="top-attach">6</property>
+                <property name="left_attach">4</property>
+                <property name="top_attach">6</property>
                 <property name="width">2</property>
               </packing>
             </child>
             <child>
               <object class="GtkComboBox" id="cb_terrain_settings__has_secondary_terrain">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <signal name="changed" handler="on_cb_terrain_settings__has_secondary_terrain_changed" swapped="no"/>
               </object>
               <packing>
-                <property name="left-attach">1</property>
-                <property name="top-attach">5</property>
+                <property name="left_attach">1</property>
+                <property name="top_attach">5</property>
                 <property name="width">2</property>
               </packing>
             </child>
             <child>
               <object class="GtkComboBox" id="cb_dead_ends">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <signal name="changed" handler="on_cb_dead_ends_changed" swapped="no"/>
               </object>
               <packing>
-                <property name="left-attach">4</property>
-                <property name="top-attach">2</property>
+                <property name="left_attach">4</property>
+                <property name="top_attach">2</property>
               </packing>
             </child>
             <child>
               <object class="GtkScale" id="scale_kecleon_shop_chance">
                 <property name="visible">True</property>
-                <property name="can-focus">True</property>
+                <property name="can_focus">True</property>
                 <property name="adjustment">adjustment_kecleon_shop_chance</property>
-                <property name="fill-level">100</property>
-                <property name="round-digits">0</property>
+                <property name="fill_level">100</property>
+                <property name="round_digits">0</property>
                 <property name="digits">0</property>
-                <property name="value-pos">right</property>
+                <property name="value_pos">right</property>
                 <signal name="value-changed" handler="on_scale_kecleon_shop_chance_value_changed" swapped="no"/>
               </object>
               <packing>
-                <property name="left-attach">1</property>
-                <property name="top-attach">14</property>
+                <property name="left_attach">1</property>
+                <property name="top_attach">14</property>
               </packing>
             </child>
             <child>
               <object class="GtkScale" id="scale_monster_house_chance">
                 <property name="visible">True</property>
-                <property name="can-focus">True</property>
+                <property name="can_focus">True</property>
                 <property name="adjustment">adjustment_monster_house_chance</property>
-                <property name="fill-level">100</property>
-                <property name="round-digits">0</property>
+                <property name="fill_level">100</property>
+                <property name="round_digits">0</property>
                 <property name="digits">0</property>
-                <property name="value-pos">right</property>
+                <property name="value_pos">right</property>
                 <signal name="value-changed" handler="on_scale_monster_house_chance_value_changed" swapped="no"/>
               </object>
               <packing>
-                <property name="left-attach">1</property>
-                <property name="top-attach">15</property>
+                <property name="left_attach">1</property>
+                <property name="top_attach">15</property>
               </packing>
             </child>
             <child>
               <object class="GtkScale" id="scale_unusued_chance">
                 <property name="visible">True</property>
-                <property name="can-focus">True</property>
+                <property name="can_focus">True</property>
                 <property name="adjustment">adjustment_unusued_change</property>
-                <property name="fill-level">100</property>
-                <property name="round-digits">0</property>
+                <property name="fill_level">100</property>
+                <property name="round_digits">0</property>
                 <property name="digits">0</property>
-                <property name="value-pos">right</property>
+                <property name="value_pos">right</property>
                 <signal name="value-changed" handler="on_scale_unusued_chance_value_changed" swapped="no"/>
               </object>
               <packing>
-                <property name="left-attach">1</property>
-                <property name="top-attach">16</property>
+                <property name="left_attach">1</property>
+                <property name="top_attach">16</property>
               </packing>
             </child>
             <child>
               <object class="GtkScale" id="scale_empty_monster_house_chance">
                 <property name="visible">True</property>
-                <property name="can-focus">True</property>
+                <property name="can_focus">True</property>
                 <property name="adjustment">adjustment_empty_monster_house_change</property>
-                <property name="fill-level">100</property>
-                <property name="round-digits">0</property>
+                <property name="fill_level">100</property>
+                <property name="round_digits">0</property>
                 <property name="digits">0</property>
-                <property name="value-pos">right</property>
+                <property name="value_pos">right</property>
                 <signal name="value-changed" handler="on_scale_empty_monster_house_chance_value_changed" swapped="no"/>
               </object>
               <packing>
-                <property name="left-attach">4</property>
-                <property name="top-attach">15</property>
+                <property name="left_attach">4</property>
+                <property name="top_attach">15</property>
               </packing>
             </child>
             <child>
               <object class="GtkScale" id="scale_sticky_item_chance">
                 <property name="visible">True</property>
-                <property name="can-focus">True</property>
+                <property name="can_focus">True</property>
                 <property name="adjustment">adjustment_sticky_item_change</property>
-                <property name="fill-level">100</property>
-                <property name="round-digits">0</property>
+                <property name="fill_level">100</property>
+                <property name="round_digits">0</property>
                 <property name="digits">0</property>
-                <property name="value-pos">right</property>
+                <property name="value_pos">right</property>
                 <signal name="value-changed" handler="on_scale_sticky_item_chance_value_changed" swapped="no"/>
               </object>
               <packing>
-                <property name="left-attach">4</property>
-                <property name="top-attach">16</property>
+                <property name="left_attach">4</property>
+                <property name="top_attach">16</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="label" translatable="yes">Shop item positions:</property>
               </object>
               <packing>
-                <property name="left-attach">3</property>
-                <property name="top-attach">19</property>
+                <property name="left_attach">3</property>
+                <property name="top_attach">19</property>
               </packing>
             </child>
             <child>
               <object class="GtkEntry" id="entry_kecleon_shop_item_positions">
                 <property name="visible">True</property>
-                <property name="can-focus">True</property>
+                <property name="can_focus">True</property>
                 <signal name="changed" handler="on_entry_kecleon_shop_item_positions_changed" swapped="no"/>
               </object>
               <packing>
-                <property name="left-attach">4</property>
-                <property name="top-attach">19</property>
+                <property name="left_attach">4</property>
+                <property name="top_attach">19</property>
               </packing>
             </child>
             <child>
               <object class="GtkButton" id="btn_help_kecleon_shop_item_positions">
                 <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="receives-default">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
                 <property name="halign">start</property>
                 <property name="valign">center</property>
                 <signal name="clicked" handler="on_btn_help_kecleon_shop_item_positions_clicked" swapped="no"/>
                 <child>
                   <object class="GtkImage">
                     <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="icon-name">skytemple-help-about-symbolic</property>
+                    <property name="can_focus">False</property>
+                    <property name="icon_name">skytemple-help-about-symbolic</property>
                   </object>
                 </child>
               </object>
               <packing>
-                <property name="left-attach">5</property>
-                <property name="top-attach">19</property>
+                <property name="left_attach">5</property>
+                <property name="top_attach">19</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="label" translatable="yes">Hidden Stairs Type:</property>
               </object>
               <packing>
-                <property name="left-attach">0</property>
-                <property name="top-attach">20</property>
+                <property name="left_attach">0</property>
+                <property name="top_attach">20</property>
               </packing>
             </child>
             <child>
               <object class="GtkEntry" id="entry_unk_hidden_stairs">
                 <property name="visible">True</property>
-                <property name="can-focus">True</property>
+                <property name="can_focus">True</property>
                 <signal name="changed" handler="on_entry_unk_hidden_stairs_changed" swapped="no"/>
               </object>
               <packing>
-                <property name="left-attach">1</property>
-                <property name="top-attach">20</property>
+                <property name="left_attach">1</property>
+                <property name="top_attach">20</property>
               </packing>
             </child>
             <child>
               <object class="GtkButton" id="btn_help_unk_hidden_stairs">
                 <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="receives-default">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
                 <property name="halign">start</property>
                 <property name="valign">center</property>
                 <signal name="clicked" handler="on_btn_help_unk_hidden_stairs_clicked" swapped="no"/>
                 <child>
                   <object class="GtkImage">
                     <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="icon-name">skytemple-help-about-symbolic</property>
+                    <property name="can_focus">False</property>
+                    <property name="icon_name">skytemple-help-about-symbolic</property>
                   </object>
                 </child>
               </object>
               <packing>
-                <property name="left-attach">2</property>
-                <property name="top-attach">20</property>
+                <property name="left_attach">2</property>
+                <property name="top_attach">20</property>
               </packing>
             </child>
             <child>
               <object class="GtkLabel">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="halign">end</property>
                 <property name="label" translatable="yes">Hidden Stairs:</property>
               </object>
               <packing>
-                <property name="left-attach">3</property>
-                <property name="top-attach">14</property>
+                <property name="left_attach">3</property>
+                <property name="top_attach">14</property>
               </packing>
             </child>
             <child>
               <object class="GtkScale" id="scale_hidden_stairs_spawn_chance">
                 <property name="visible">True</property>
-                <property name="can-focus">True</property>
+                <property name="can_focus">True</property>
                 <property name="adjustment">adjustment_hidden_stairs_change</property>
-                <property name="fill-level">100</property>
-                <property name="round-digits">0</property>
+                <property name="fill_level">100</property>
+                <property name="round_digits">0</property>
                 <property name="digits">0</property>
-                <property name="value-pos">right</property>
+                <property name="value_pos">right</property>
                 <signal name="value-changed" handler="on_scale_hidden_stairs_spawn_chance_value_changed" swapped="no"/>
               </object>
               <packing>
-                <property name="left-attach">4</property>
-                <property name="top-attach">14</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkLabel">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-              </object>
-              <packing>
-                <property name="left-attach">3</property>
-                <property name="top-attach">20</property>
-                <property name="width">3</property>
+                <property name="left_attach">4</property>
+                <property name="top_attach">14</property>
               </packing>
             </child>
             <child>
               <object class="GtkButton" id="btn_help_room_density">
                 <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="receives-default">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
                 <property name="halign">start</property>
                 <property name="valign">center</property>
                 <signal name="clicked" handler="on_btn_help_room_density_clicked" swapped="no"/>
                 <child>
                   <object class="GtkImage">
                     <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="icon-name">skytemple-help-about-symbolic</property>
+                    <property name="can_focus">False</property>
+                    <property name="icon_name">skytemple-help-about-symbolic</property>
                   </object>
                 </child>
               </object>
               <packing>
-                <property name="left-attach">5</property>
-                <property name="top-attach">1</property>
+                <property name="left_attach">5</property>
+                <property name="top_attach">1</property>
               </packing>
             </child>
             <child>
               <object class="GtkButton" id="btn_help_dead_ends">
                 <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="receives-default">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
                 <property name="halign">start</property>
                 <property name="valign">center</property>
                 <signal name="clicked" handler="on_btn_help_dead_ends_clicked" swapped="no"/>
                 <child>
                   <object class="GtkImage">
                     <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="icon-name">skytemple-help-about-symbolic</property>
+                    <property name="can_focus">False</property>
+                    <property name="icon_name">skytemple-help-about-symbolic</property>
                   </object>
                 </child>
               </object>
               <packing>
-                <property name="left-attach">5</property>
-                <property name="top-attach">2</property>
+                <property name="left_attach">5</property>
+                <property name="top_attach">2</property>
               </packing>
             </child>
             <child>
               <object class="GtkButton" id="btn_help_empty_monster_house">
                 <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="receives-default">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
                 <property name="halign">start</property>
                 <property name="valign">center</property>
                 <signal name="clicked" handler="on_btn_help_empty_monster_house_clicked" swapped="no"/>
                 <child>
                   <object class="GtkImage">
                     <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="icon-name">skytemple-help-about-symbolic</property>
+                    <property name="can_focus">False</property>
+                    <property name="icon_name">skytemple-help-about-symbolic</property>
                   </object>
                 </child>
               </object>
               <packing>
-                <property name="left-attach">5</property>
-                <property name="top-attach">15</property>
+                <property name="left_attach">5</property>
+                <property name="top_attach">15</property>
               </packing>
             </child>
             <child>
               <object class="GtkButton" id="btn_help_unusued_chance">
                 <property name="visible">True</property>
-                <property name="can-focus">True</property>
-                <property name="receives-default">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
                 <property name="halign">start</property>
                 <property name="valign">center</property>
                 <signal name="clicked" handler="on_btn_help_unusued_chance_clicked" swapped="no"/>
                 <child>
                   <object class="GtkImage">
                     <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="icon-name">skytemple-help-about-symbolic</property>
+                    <property name="can_focus">False</property>
+                    <property name="icon_name">skytemple-help-about-symbolic</property>
                   </object>
                 </child>
               </object>
               <packing>
-                <property name="left-attach">2</property>
-                <property name="top-attach">16</property>
+                <property name="left_attach">2</property>
+                <property name="top_attach">16</property>
               </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="halign">end</property>
+                <property name="label" translatable="yes">Floor Rank:</property>
+              </object>
+              <packing>
+                <property name="left_attach">0</property>
+                <property name="top_attach">21</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkComboBox" id="cb_floor_ranks">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <signal name="changed" handler="on_cb_floor_ranks_changed" swapped="no"/>
+              </object>
+              <packing>
+                <property name="left_attach">1</property>
+                <property name="top_attach">21</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="btn_help_floor_ranks">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="halign">start</property>
+                <property name="valign">center</property>
+                <signal name="clicked" handler="on_btn_help_floor_ranks_clicked" swapped="no"/>
+                <child>
+                  <object class="GtkImage">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="icon_name">skytemple-help-about-symbolic</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="left_attach">2</property>
+                <property name="top_attach">21</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="halign">end</property>
+                <property name="label" translatable="yes">No Missions: </property>
+              </object>
+              <packing>
+                <property name="left_attach">3</property>
+                <property name="top_attach">21</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkComboBox" id="cb_mission_forbidden">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <signal name="changed" handler="on_cb_mission_forbidden_changed" swapped="no"/>
+              </object>
+              <packing>
+                <property name="left_attach">4</property>
+                <property name="top_attach">21</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="btn_help_mission_forbidden">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="halign">start</property>
+                <property name="valign">center</property>
+                <signal name="clicked" handler="on_btn_help_mission_forbidden_clicked" swapped="no"/>
+                <child>
+                  <object class="GtkImage">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="icon_name">skytemple-help-about-symbolic</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="left_attach">5</property>
+                <property name="top_attach">21</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="halign">end</property>
+                <property name="label" translatable="yes">Room Density:</property>
+              </object>
+              <packing>
+                <property name="left_attach">3</property>
+                <property name="top_attach">1</property>
+              </packing>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
             </child>
             <child>
               <placeholder/>
@@ -2562,34 +2653,34 @@
         <child type="tab">
           <object class="GtkLabel">
             <property name="visible">True</property>
-            <property name="can-focus">False</property>
+            <property name="can_focus">False</property>
             <property name="label" translatable="yes">Layout</property>
           </object>
           <packing>
-            <property name="tab-fill">False</property>
+            <property name="tab_fill">False</property>
           </packing>
         </child>
         <child>
           <object class="GtkAlignment">
             <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="xscale">0.8000000119209289</property>
-            <property name="yscale">0.8000000119209289</property>
+            <property name="can_focus">False</property>
+            <property name="xscale">0.80000001192092896</property>
+            <property name="yscale">0.80000001192092896</property>
             <child>
               <object class="GtkBox">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="orientation">vertical</property>
                 <property name="spacing">10</property>
                 <child>
                   <object class="GtkScrolledWindow">
                     <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="shadow-type">in</property>
+                    <property name="can_focus">True</property>
+                    <property name="shadow_type">in</property>
                     <child>
                       <object class="GtkTreeView" id="monster_spawns_tree">
                         <property name="visible">True</property>
-                        <property name="can-focus">True</property>
+                        <property name="can_focus">True</property>
                         <property name="model">monster_spawns_store</property>
                         <child internal-child="selection">
                           <object class="GtkTreeSelection"/>
@@ -2668,27 +2759,27 @@
                 <child>
                   <object class="GtkBox">
                     <property name="visible">True</property>
-                    <property name="can-focus">False</property>
+                    <property name="can_focus">False</property>
                     <property name="spacing">10</property>
                     <child>
                       <object class="GtkButton" id="btn_help_monster_spawn_table">
                         <property name="visible">True</property>
-                        <property name="can-focus">True</property>
-                        <property name="receives-default">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
                         <property name="halign">start</property>
                         <property name="valign">center</property>
-                        <property name="margin-end">10</property>
+                        <property name="margin_end">10</property>
                         <signal name="clicked" handler="on_btn_help__spawn_tables__clicked" swapped="no"/>
                         <child>
                           <object class="GtkBox">
                             <property name="visible">True</property>
-                            <property name="can-focus">False</property>
+                            <property name="can_focus">False</property>
                             <property name="spacing">5</property>
                             <child>
                               <object class="GtkImage">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="icon-name">skytemple-help-about-symbolic</property>
+                                <property name="can_focus">False</property>
+                                <property name="icon_name">skytemple-help-about-symbolic</property>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -2699,7 +2790,7 @@
                             <child>
                               <object class="GtkLabel">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
+                                <property name="can_focus">False</property>
                                 <property name="label" translatable="yes">Help</property>
                               </object>
                               <packing>
@@ -2720,7 +2811,7 @@
                     <child>
                       <object class="GtkLabel">
                         <property name="visible">True</property>
-                        <property name="can-focus">False</property>
+                        <property name="can_focus">False</property>
                         <property name="label" translatable="yes">Kecleon Level </property>
                       </object>
                       <packing>
@@ -2732,8 +2823,8 @@
                     <child>
                       <object class="GtkEntry" id="kecleon_level_entry">
                         <property name="visible">True</property>
-                        <property name="can-focus">True</property>
-                        <property name="width-chars">4</property>
+                        <property name="can_focus">True</property>
+                        <property name="width_chars">4</property>
                         <signal name="changed" handler="on_kecleon_level_entry_changed" swapped="no"/>
                       </object>
                       <packing>
@@ -2745,42 +2836,42 @@
                     <child>
                       <object class="GtkButton" id="monster_spawns_add">
                         <property name="visible">True</property>
-                        <property name="can-focus">True</property>
-                        <property name="receives-default">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
                         <signal name="clicked" handler="on_monster_spawns_add_clicked" swapped="no"/>
                         <child>
                           <object class="GtkImage">
                             <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="icon-name">skytemple-list-add-symbolic</property>
+                            <property name="can_focus">False</property>
+                            <property name="icon_name">skytemple-list-add-symbolic</property>
                           </object>
                         </child>
                       </object>
                       <packing>
                         <property name="expand">False</property>
                         <property name="fill">True</property>
-                        <property name="pack-type">end</property>
+                        <property name="pack_type">end</property>
                         <property name="position">2</property>
                       </packing>
                     </child>
                     <child>
                       <object class="GtkButton" id="monster_spawns_remove">
                         <property name="visible">True</property>
-                        <property name="can-focus">True</property>
-                        <property name="receives-default">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
                         <signal name="clicked" handler="on_monster_spawns_remove_clicked" swapped="no"/>
                         <child>
                           <object class="GtkImage">
                             <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="icon-name">skytemple-list-remove-symbolic</property>
+                            <property name="can_focus">False</property>
+                            <property name="icon_name">skytemple-list-remove-symbolic</property>
                           </object>
                         </child>
                       </object>
                       <packing>
                         <property name="expand">False</property>
                         <property name="fill">True</property>
-                        <property name="pack-type">end</property>
+                        <property name="pack_type">end</property>
                         <property name="position">4</property>
                       </packing>
                     </child>
@@ -2801,37 +2892,37 @@
         <child type="tab">
           <object class="GtkLabel">
             <property name="visible">True</property>
-            <property name="can-focus">False</property>
+            <property name="can_focus">False</property>
             <property name="label" translatable="yes">Pokémon Spawns</property>
           </object>
           <packing>
             <property name="position">1</property>
-            <property name="tab-fill">False</property>
+            <property name="tab_fill">False</property>
           </packing>
         </child>
         <child>
           <object class="GtkAlignment">
             <property name="visible">True</property>
-            <property name="can-focus">False</property>
-            <property name="xscale">0.8000000119209289</property>
-            <property name="yscale">0.8000000119209289</property>
+            <property name="can_focus">False</property>
+            <property name="xscale">0.80000001192092896</property>
+            <property name="yscale">0.80000001192092896</property>
             <child>
               <object class="GtkBox">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="orientation">vertical</property>
                 <property name="spacing">10</property>
                 <child>
                   <object class="GtkScrolledWindow">
                     <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="shadow-type">in</property>
+                    <property name="can_focus">True</property>
+                    <property name="shadow_type">in</property>
                     <child>
                       <object class="GtkTreeView" id="trap_spawns_tree">
                         <property name="visible">True</property>
-                        <property name="can-focus">True</property>
+                        <property name="can_focus">True</property>
                         <property name="model">trap_spawns_store</property>
-                        <property name="search-column">0</property>
+                        <property name="search_column">0</property>
                         <child internal-child="selection">
                           <object class="GtkTreeSelection"/>
                         </child>
@@ -2885,27 +2976,27 @@
                 <child>
                   <object class="GtkBox">
                     <property name="visible">True</property>
-                    <property name="can-focus">False</property>
+                    <property name="can_focus">False</property>
                     <child>
                       <object class="GtkButton" id="btn_help_trap_spawn_table">
                         <property name="visible">True</property>
-                        <property name="can-focus">True</property>
-                        <property name="receives-default">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
                         <property name="halign">start</property>
                         <property name="valign">center</property>
-                        <property name="margin-right">10</property>
-                        <property name="margin-end">10</property>
+                        <property name="margin_right">10</property>
+                        <property name="margin_end">10</property>
                         <signal name="clicked" handler="on_btn_help__spawn_tables__clicked" swapped="no"/>
                         <child>
                           <object class="GtkBox">
                             <property name="visible">True</property>
-                            <property name="can-focus">False</property>
+                            <property name="can_focus">False</property>
                             <property name="spacing">5</property>
                             <child>
                               <object class="GtkImage">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="icon-name">skytemple-help-about-symbolic</property>
+                                <property name="can_focus">False</property>
+                                <property name="icon_name">skytemple-help-about-symbolic</property>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -2916,7 +3007,7 @@
                             <child>
                               <object class="GtkLabel">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
+                                <property name="can_focus">False</property>
                                 <property name="label" translatable="yes">Help</property>
                               </object>
                               <packing>
@@ -2951,78 +3042,78 @@
         <child type="tab">
           <object class="GtkLabel">
             <property name="visible">True</property>
-            <property name="can-focus">False</property>
+            <property name="can_focus">False</property>
             <property name="label" translatable="yes">Traps</property>
           </object>
           <packing>
             <property name="position">2</property>
-            <property name="tab-fill">False</property>
+            <property name="tab_fill">False</property>
           </packing>
         </child>
         <child>
           <object class="GtkNotebook" id="item_list_notebook">
             <property name="visible">True</property>
-            <property name="can-focus">True</property>
+            <property name="can_focus">True</property>
             <signal name="switch-page" handler="on_item_list_notebook_switch_page" swapped="no"/>
             <child>
               <object class="GtkBox">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <object class="GtkScrolledWindow" id="sw_item_editor">
                     <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="shadow-type">in</property>
+                    <property name="can_focus">True</property>
+                    <property name="shadow_type">in</property>
                     <child>
                       <object class="GtkViewport">
                         <property name="visible">True</property>
-                        <property name="can-focus">False</property>
+                        <property name="can_focus">False</property>
                         <child>
                           <object class="GtkBox">
                             <property name="visible">True</property>
-                            <property name="can-focus">False</property>
-                            <property name="margin-left">5</property>
-                            <property name="margin-right">5</property>
-                            <property name="margin-start">5</property>
-                            <property name="margin-end">5</property>
-                            <property name="margin-top">5</property>
-                            <property name="margin-bottom">5</property>
+                            <property name="can_focus">False</property>
+                            <property name="margin_left">5</property>
+                            <property name="margin_right">5</property>
+                            <property name="margin_start">5</property>
+                            <property name="margin_end">5</property>
+                            <property name="margin_top">5</property>
+                            <property name="margin_bottom">5</property>
                             <property name="orientation">vertical</property>
                             <property name="spacing">10</property>
                             <child>
                               <object class="GtkFrame">
-                                <property name="height-request">225</property>
+                                <property name="height_request">225</property>
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0</property>
-                                <property name="shadow-type">none</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0</property>
+                                <property name="shadow_type">none</property>
                                 <child>
                                   <object class="GtkAlignment">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="left-padding">12</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="left_padding">12</property>
                                     <child>
                                       <object class="GtkBox">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">False</property>
+                                        <property name="can_focus">False</property>
                                         <property name="orientation">vertical</property>
                                         <property name="spacing">5</property>
                                         <child>
                                           <object class="GtkScrolledWindow">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">True</property>
-                                            <property name="shadow-type">in</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="shadow_type">in</property>
                                             <child>
                                               <object class="GtkViewport">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <child>
                                                   <object class="GtkTreeView" id="item_categories_tree">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">True</property>
+                                                    <property name="can_focus">True</property>
                                                     <property name="model">item_categories_store</property>
-                                                    <property name="search-column">0</property>
+                                                    <property name="search_column">0</property>
                                                     <child internal-child="selection">
                                                       <object class="GtkTreeSelection"/>
                                                     </child>
@@ -3033,7 +3124,7 @@
                                                           <object class="GtkCellRendererCombo" id="cr_items_cat_name">
                                                             <property name="editable">True</property>
                                                             <property name="model">cr_item_cat_name_store</property>
-                                                            <property name="text-column">1</property>
+                                                            <property name="text_column">1</property>
                                                             <signal name="changed" handler="on_cr_items_cat_name_changed" swapped="no"/>
                                                           </object>
                                                           <attributes>
@@ -3082,20 +3173,20 @@
                                         <child>
                                           <object class="GtkBox">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="halign">end</property>
                                             <property name="spacing">10</property>
                                             <child>
                                               <object class="GtkButton" id="item_categories_add">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
-                                                <property name="receives-default">True</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="receives_default">True</property>
                                                 <signal name="clicked" handler="on_item_categories_add_clicked" swapped="no"/>
                                                 <child>
                                                   <object class="GtkImage">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
-                                                    <property name="icon-name">skytemple-list-add-symbolic</property>
+                                                    <property name="can_focus">False</property>
+                                                    <property name="icon_name">skytemple-list-add-symbolic</property>
                                                   </object>
                                                 </child>
                                               </object>
@@ -3108,14 +3199,14 @@
                                             <child>
                                               <object class="GtkButton" id="item_categories_remove">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
-                                                <property name="receives-default">True</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="receives_default">True</property>
                                                 <signal name="clicked" handler="on_item_categories_remove_clicked" swapped="no"/>
                                                 <child>
                                                   <object class="GtkImage">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
-                                                    <property name="icon-name">skytemple-list-remove-symbolic</property>
+                                                    <property name="can_focus">False</property>
+                                                    <property name="icon_name">skytemple-list-remove-symbolic</property>
                                                   </object>
                                                 </child>
                                               </object>
@@ -3139,8 +3230,8 @@
                                 <child type="label">
                                   <object class="GtkLabel">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-bottom">5</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="margin_bottom">5</property>
                                     <property name="label" translatable="yes">Categories</property>
                                   </object>
                                 </child>
@@ -3154,42 +3245,42 @@
                             <child>
                               <object class="GtkFrame">
                                 <property name="visible">True</property>
-                                <property name="can-focus">False</property>
-                                <property name="label-xalign">0</property>
-                                <property name="shadow-type">none</property>
+                                <property name="can_focus">False</property>
+                                <property name="label_xalign">0</property>
+                                <property name="shadow_type">none</property>
                                 <child>
                                   <object class="GtkAlignment">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="left-padding">12</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="left_padding">12</property>
                                     <child>
                                       <object class="GtkNotebook">
                                         <property name="visible">True</property>
-                                        <property name="can-focus">True</property>
+                                        <property name="can_focus">True</property>
                                         <property name="scrollable">True</property>
-                                        <property name="enable-popup">True</property>
+                                        <property name="enable_popup">True</property>
                                         <child>
                                           <object class="GtkBox">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="margin-bottom">5</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="margin_bottom">5</property>
                                             <property name="orientation">vertical</property>
                                             <property name="spacing">5</property>
                                             <child>
                                               <object class="GtkScrolledWindow">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
-                                                <property name="shadow-type">in</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="shadow_type">in</property>
                                                 <child>
                                                   <object class="GtkViewport">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
+                                                    <property name="can_focus">False</property>
                                                     <child>
                                                       <object class="GtkTreeView" id="item_cat_thrown_pierce_tree">
                                                         <property name="visible">True</property>
-                                                        <property name="can-focus">True</property>
+                                                        <property name="can_focus">True</property>
                                                         <property name="model">item_cat_thrown_pierce_store</property>
-                                                        <property name="search-column">0</property>
+                                                        <property name="search_column">0</property>
                                                         <child internal-child="selection">
                                                           <object class="GtkTreeSelection"/>
                                                         </child>
@@ -3261,21 +3352,21 @@
                                             <child>
                                               <object class="GtkBox">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="halign">end</property>
-                                                <property name="margin-end">5</property>
+                                                <property name="margin_end">5</property>
                                                 <property name="spacing">10</property>
                                                 <child>
                                                   <object class="GtkButton" id="item_cat_thrown_pierce_add">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">True</property>
-                                                    <property name="receives-default">True</property>
+                                                    <property name="can_focus">True</property>
+                                                    <property name="receives_default">True</property>
                                                     <signal name="clicked" handler="on_item_cat_thrown_pierce_add_clicked" swapped="no"/>
                                                     <child>
                                                       <object class="GtkImage">
                                                         <property name="visible">True</property>
-                                                        <property name="can-focus">False</property>
-                                                        <property name="icon-name">skytemple-list-add-symbolic</property>
+                                                        <property name="can_focus">False</property>
+                                                        <property name="icon_name">skytemple-list-add-symbolic</property>
                                                       </object>
                                                     </child>
                                                   </object>
@@ -3288,14 +3379,14 @@
                                                 <child>
                                                   <object class="GtkButton" id="item_cat_thrown_pierce_remove">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">True</property>
-                                                    <property name="receives-default">True</property>
+                                                    <property name="can_focus">True</property>
+                                                    <property name="receives_default">True</property>
                                                     <signal name="clicked" handler="on_item_cat_thrown_pierce_remove_clicked" swapped="no"/>
                                                     <child>
                                                       <object class="GtkImage">
                                                         <property name="visible">True</property>
-                                                        <property name="can-focus">False</property>
-                                                        <property name="icon-name">skytemple-list-remove-symbolic</property>
+                                                        <property name="can_focus">False</property>
+                                                        <property name="icon_name">skytemple-list-remove-symbolic</property>
                                                       </object>
                                                     </child>
                                                   </object>
@@ -3317,35 +3408,35 @@
                                         <child type="tab">
                                           <object class="GtkLabel">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">Thrown - Pierce</property>
                                           </object>
                                           <packing>
-                                            <property name="tab-fill">False</property>
+                                            <property name="tab_fill">False</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkBox">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="margin-bottom">5</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="margin_bottom">5</property>
                                             <property name="orientation">vertical</property>
                                             <property name="spacing">5</property>
                                             <child>
                                               <object class="GtkScrolledWindow">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
-                                                <property name="shadow-type">in</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="shadow_type">in</property>
                                                 <child>
                                                   <object class="GtkViewport">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
+                                                    <property name="can_focus">False</property>
                                                     <child>
                                                       <object class="GtkTreeView" id="item_cat_thrown_rock_tree">
                                                         <property name="visible">True</property>
-                                                        <property name="can-focus">True</property>
+                                                        <property name="can_focus">True</property>
                                                         <property name="model">item_cat_thrown_rock_store</property>
-                                                        <property name="search-column">0</property>
+                                                        <property name="search_column">0</property>
                                                         <child internal-child="selection">
                                                           <object class="GtkTreeSelection"/>
                                                         </child>
@@ -3417,21 +3508,21 @@
                                             <child>
                                               <object class="GtkBox">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="halign">end</property>
-                                                <property name="margin-end">5</property>
+                                                <property name="margin_end">5</property>
                                                 <property name="spacing">10</property>
                                                 <child>
                                                   <object class="GtkButton" id="item_cat_thrown_rock_add">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">True</property>
-                                                    <property name="receives-default">True</property>
+                                                    <property name="can_focus">True</property>
+                                                    <property name="receives_default">True</property>
                                                     <signal name="clicked" handler="on_item_cat_thrown_rock_add_clicked" swapped="no"/>
                                                     <child>
                                                       <object class="GtkImage">
                                                         <property name="visible">True</property>
-                                                        <property name="can-focus">False</property>
-                                                        <property name="icon-name">skytemple-list-add-symbolic</property>
+                                                        <property name="can_focus">False</property>
+                                                        <property name="icon_name">skytemple-list-add-symbolic</property>
                                                       </object>
                                                     </child>
                                                   </object>
@@ -3444,14 +3535,14 @@
                                                 <child>
                                                   <object class="GtkButton" id="item_cat_thrown_rock_remove">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">True</property>
-                                                    <property name="receives-default">True</property>
+                                                    <property name="can_focus">True</property>
+                                                    <property name="receives_default">True</property>
                                                     <signal name="clicked" handler="on_item_cat_thrown_rock_remove_clicked" swapped="no"/>
                                                     <child>
                                                       <object class="GtkImage">
                                                         <property name="visible">True</property>
-                                                        <property name="can-focus">False</property>
-                                                        <property name="icon-name">skytemple-list-remove-symbolic</property>
+                                                        <property name="can_focus">False</property>
+                                                        <property name="icon_name">skytemple-list-remove-symbolic</property>
                                                       </object>
                                                     </child>
                                                   </object>
@@ -3476,36 +3567,36 @@
                                         <child type="tab">
                                           <object class="GtkLabel">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">Thrown - Rock</property>
                                           </object>
                                           <packing>
                                             <property name="position">1</property>
-                                            <property name="tab-fill">False</property>
+                                            <property name="tab_fill">False</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkBox">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="margin-bottom">5</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="margin_bottom">5</property>
                                             <property name="orientation">vertical</property>
                                             <property name="spacing">5</property>
                                             <child>
                                               <object class="GtkScrolledWindow">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
-                                                <property name="shadow-type">in</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="shadow_type">in</property>
                                                 <child>
                                                   <object class="GtkViewport">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
+                                                    <property name="can_focus">False</property>
                                                     <child>
                                                       <object class="GtkTreeView" id="item_cat_berries_tree">
                                                         <property name="visible">True</property>
-                                                        <property name="can-focus">True</property>
+                                                        <property name="can_focus">True</property>
                                                         <property name="model">item_cat_berries_store</property>
-                                                        <property name="search-column">0</property>
+                                                        <property name="search_column">0</property>
                                                         <child internal-child="selection">
                                                           <object class="GtkTreeSelection"/>
                                                         </child>
@@ -3577,22 +3668,22 @@
                                             <child>
                                               <object class="GtkBox">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="halign">end</property>
-                                                <property name="margin-right">5</property>
-                                                <property name="margin-end">5</property>
+                                                <property name="margin_right">5</property>
+                                                <property name="margin_end">5</property>
                                                 <property name="spacing">10</property>
                                                 <child>
                                                   <object class="GtkButton" id="item_cat_berries_add">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">True</property>
-                                                    <property name="receives-default">True</property>
+                                                    <property name="can_focus">True</property>
+                                                    <property name="receives_default">True</property>
                                                     <signal name="clicked" handler="on_item_cat_berries_add_clicked" swapped="no"/>
                                                     <child>
                                                       <object class="GtkImage">
                                                         <property name="visible">True</property>
-                                                        <property name="can-focus">False</property>
-                                                        <property name="icon-name">skytemple-list-add-symbolic</property>
+                                                        <property name="can_focus">False</property>
+                                                        <property name="icon_name">skytemple-list-add-symbolic</property>
                                                       </object>
                                                     </child>
                                                   </object>
@@ -3605,14 +3696,14 @@
                                                 <child>
                                                   <object class="GtkButton" id="item_cat_berries_remove">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">True</property>
-                                                    <property name="receives-default">True</property>
+                                                    <property name="can_focus">True</property>
+                                                    <property name="receives_default">True</property>
                                                     <signal name="clicked" handler="on_item_cat_berries_remove_clicked" swapped="no"/>
                                                     <child>
                                                       <object class="GtkImage">
                                                         <property name="visible">True</property>
-                                                        <property name="can-focus">False</property>
-                                                        <property name="icon-name">skytemple-list-remove-symbolic</property>
+                                                        <property name="can_focus">False</property>
+                                                        <property name="icon_name">skytemple-list-remove-symbolic</property>
                                                       </object>
                                                     </child>
                                                   </object>
@@ -3637,36 +3728,36 @@
                                         <child type="tab">
                                           <object class="GtkLabel">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">Berries, Seeds, Vitamins</property>
                                           </object>
                                           <packing>
                                             <property name="position">2</property>
-                                            <property name="tab-fill">False</property>
+                                            <property name="tab_fill">False</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkBox">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="margin-bottom">5</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="margin_bottom">5</property>
                                             <property name="orientation">vertical</property>
                                             <property name="spacing">5</property>
                                             <child>
                                               <object class="GtkScrolledWindow">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
-                                                <property name="shadow-type">in</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="shadow_type">in</property>
                                                 <child>
                                                   <object class="GtkViewport">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
+                                                    <property name="can_focus">False</property>
                                                     <child>
                                                       <object class="GtkTreeView" id="item_cat_foods_tree">
                                                         <property name="visible">True</property>
-                                                        <property name="can-focus">True</property>
+                                                        <property name="can_focus">True</property>
                                                         <property name="model">item_cat_foods_store</property>
-                                                        <property name="search-column">0</property>
+                                                        <property name="search_column">0</property>
                                                         <child internal-child="selection">
                                                           <object class="GtkTreeSelection"/>
                                                         </child>
@@ -3738,22 +3829,22 @@
                                             <child>
                                               <object class="GtkBox">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="halign">end</property>
-                                                <property name="margin-right">5</property>
-                                                <property name="margin-end">5</property>
+                                                <property name="margin_right">5</property>
+                                                <property name="margin_end">5</property>
                                                 <property name="spacing">10</property>
                                                 <child>
                                                   <object class="GtkButton" id="item_cat_foods_add">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">True</property>
-                                                    <property name="receives-default">True</property>
+                                                    <property name="can_focus">True</property>
+                                                    <property name="receives_default">True</property>
                                                     <signal name="clicked" handler="on_item_cat_foods_add_clicked" swapped="no"/>
                                                     <child>
                                                       <object class="GtkImage">
                                                         <property name="visible">True</property>
-                                                        <property name="can-focus">False</property>
-                                                        <property name="icon-name">skytemple-list-add-symbolic</property>
+                                                        <property name="can_focus">False</property>
+                                                        <property name="icon_name">skytemple-list-add-symbolic</property>
                                                       </object>
                                                     </child>
                                                   </object>
@@ -3766,14 +3857,14 @@
                                                 <child>
                                                   <object class="GtkButton" id="item_cat_foods_remove">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">True</property>
-                                                    <property name="receives-default">True</property>
+                                                    <property name="can_focus">True</property>
+                                                    <property name="receives_default">True</property>
                                                     <signal name="clicked" handler="on_item_cat_foods_remove_clicked" swapped="no"/>
                                                     <child>
                                                       <object class="GtkImage">
                                                         <property name="visible">True</property>
-                                                        <property name="can-focus">False</property>
-                                                        <property name="icon-name">skytemple-list-remove-symbolic</property>
+                                                        <property name="can_focus">False</property>
+                                                        <property name="icon_name">skytemple-list-remove-symbolic</property>
                                                       </object>
                                                     </child>
                                                   </object>
@@ -3798,36 +3889,36 @@
                                         <child type="tab">
                                           <object class="GtkLabel">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">Foods, Gummies</property>
                                           </object>
                                           <packing>
                                             <property name="position">3</property>
-                                            <property name="tab-fill">False</property>
+                                            <property name="tab_fill">False</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkBox">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="margin-bottom">5</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="margin_bottom">5</property>
                                             <property name="orientation">vertical</property>
                                             <property name="spacing">5</property>
                                             <child>
                                               <object class="GtkScrolledWindow">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
-                                                <property name="shadow-type">in</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="shadow_type">in</property>
                                                 <child>
                                                   <object class="GtkViewport">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
+                                                    <property name="can_focus">False</property>
                                                     <child>
                                                       <object class="GtkTreeView" id="item_cat_hold_tree">
                                                         <property name="visible">True</property>
-                                                        <property name="can-focus">True</property>
+                                                        <property name="can_focus">True</property>
                                                         <property name="model">item_cat_hold_store</property>
-                                                        <property name="search-column">0</property>
+                                                        <property name="search_column">0</property>
                                                         <child internal-child="selection">
                                                           <object class="GtkTreeSelection"/>
                                                         </child>
@@ -3899,22 +3990,22 @@
                                             <child>
                                               <object class="GtkBox">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="halign">end</property>
-                                                <property name="margin-right">5</property>
-                                                <property name="margin-end">5</property>
+                                                <property name="margin_right">5</property>
+                                                <property name="margin_end">5</property>
                                                 <property name="spacing">10</property>
                                                 <child>
                                                   <object class="GtkButton" id="item_cat_hold_add">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">True</property>
-                                                    <property name="receives-default">True</property>
+                                                    <property name="can_focus">True</property>
+                                                    <property name="receives_default">True</property>
                                                     <signal name="clicked" handler="on_item_cat_hold_add_clicked" swapped="no"/>
                                                     <child>
                                                       <object class="GtkImage">
                                                         <property name="visible">True</property>
-                                                        <property name="can-focus">False</property>
-                                                        <property name="icon-name">skytemple-list-add-symbolic</property>
+                                                        <property name="can_focus">False</property>
+                                                        <property name="icon_name">skytemple-list-add-symbolic</property>
                                                       </object>
                                                     </child>
                                                   </object>
@@ -3927,14 +4018,14 @@
                                                 <child>
                                                   <object class="GtkButton" id="item_cat_hold_remove">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">True</property>
-                                                    <property name="receives-default">True</property>
+                                                    <property name="can_focus">True</property>
+                                                    <property name="receives_default">True</property>
                                                     <signal name="clicked" handler="on_item_cat_hold_remove_clicked" swapped="no"/>
                                                     <child>
                                                       <object class="GtkImage">
                                                         <property name="visible">True</property>
-                                                        <property name="can-focus">False</property>
-                                                        <property name="icon-name">skytemple-list-remove-symbolic</property>
+                                                        <property name="can_focus">False</property>
+                                                        <property name="icon_name">skytemple-list-remove-symbolic</property>
                                                       </object>
                                                     </child>
                                                   </object>
@@ -3959,36 +4050,36 @@
                                         <child type="tab">
                                           <object class="GtkLabel">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">Hold</property>
                                           </object>
                                           <packing>
                                             <property name="position">4</property>
-                                            <property name="tab-fill">False</property>
+                                            <property name="tab_fill">False</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkBox">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="margin-bottom">5</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="margin_bottom">5</property>
                                             <property name="orientation">vertical</property>
                                             <property name="spacing">5</property>
                                             <child>
                                               <object class="GtkScrolledWindow">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
-                                                <property name="shadow-type">in</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="shadow_type">in</property>
                                                 <child>
                                                   <object class="GtkViewport">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
+                                                    <property name="can_focus">False</property>
                                                     <child>
                                                       <object class="GtkTreeView" id="item_cat_tms_tree">
                                                         <property name="visible">True</property>
-                                                        <property name="can-focus">True</property>
+                                                        <property name="can_focus">True</property>
                                                         <property name="model">item_cat_tms_store</property>
-                                                        <property name="search-column">0</property>
+                                                        <property name="search_column">0</property>
                                                         <child internal-child="selection">
                                                           <object class="GtkTreeSelection"/>
                                                         </child>
@@ -4060,22 +4151,22 @@
                                             <child>
                                               <object class="GtkBox">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="halign">end</property>
-                                                <property name="margin-right">5</property>
-                                                <property name="margin-end">5</property>
+                                                <property name="margin_right">5</property>
+                                                <property name="margin_end">5</property>
                                                 <property name="spacing">10</property>
                                                 <child>
                                                   <object class="GtkButton" id="item_cat_tms_add">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">True</property>
-                                                    <property name="receives-default">True</property>
+                                                    <property name="can_focus">True</property>
+                                                    <property name="receives_default">True</property>
                                                     <signal name="clicked" handler="on_item_cat_tms_add_clicked" swapped="no"/>
                                                     <child>
                                                       <object class="GtkImage">
                                                         <property name="visible">True</property>
-                                                        <property name="can-focus">False</property>
-                                                        <property name="icon-name">skytemple-list-add-symbolic</property>
+                                                        <property name="can_focus">False</property>
+                                                        <property name="icon_name">skytemple-list-add-symbolic</property>
                                                       </object>
                                                     </child>
                                                   </object>
@@ -4088,14 +4179,14 @@
                                                 <child>
                                                   <object class="GtkButton" id="item_cat_tms_remove">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">True</property>
-                                                    <property name="receives-default">True</property>
+                                                    <property name="can_focus">True</property>
+                                                    <property name="receives_default">True</property>
                                                     <signal name="clicked" handler="on_item_cat_tms_remove_clicked" swapped="no"/>
                                                     <child>
                                                       <object class="GtkImage">
                                                         <property name="visible">True</property>
-                                                        <property name="can-focus">False</property>
-                                                        <property name="icon-name">skytemple-list-remove-symbolic</property>
+                                                        <property name="can_focus">False</property>
+                                                        <property name="icon_name">skytemple-list-remove-symbolic</property>
                                                       </object>
                                                     </child>
                                                   </object>
@@ -4120,36 +4211,36 @@
                                         <child type="tab">
                                           <object class="GtkLabel">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">TMs, HMs</property>
                                           </object>
                                           <packing>
                                             <property name="position">5</property>
-                                            <property name="tab-fill">False</property>
+                                            <property name="tab_fill">False</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkBox">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="margin-bottom">5</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="margin_bottom">5</property>
                                             <property name="orientation">vertical</property>
                                             <property name="spacing">5</property>
                                             <child>
                                               <object class="GtkScrolledWindow">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
-                                                <property name="shadow-type">in</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="shadow_type">in</property>
                                                 <child>
                                                   <object class="GtkViewport">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
+                                                    <property name="can_focus">False</property>
                                                     <child>
                                                       <object class="GtkTreeView" id="item_cat_orbs_tree">
                                                         <property name="visible">True</property>
-                                                        <property name="can-focus">True</property>
+                                                        <property name="can_focus">True</property>
                                                         <property name="model">item_cat_orbs_store</property>
-                                                        <property name="search-column">0</property>
+                                                        <property name="search_column">0</property>
                                                         <child internal-child="selection">
                                                           <object class="GtkTreeSelection"/>
                                                         </child>
@@ -4221,22 +4312,22 @@
                                             <child>
                                               <object class="GtkBox">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="halign">end</property>
-                                                <property name="margin-right">5</property>
-                                                <property name="margin-end">5</property>
+                                                <property name="margin_right">5</property>
+                                                <property name="margin_end">5</property>
                                                 <property name="spacing">10</property>
                                                 <child>
                                                   <object class="GtkButton" id="item_cat_orbs_add">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">True</property>
-                                                    <property name="receives-default">True</property>
+                                                    <property name="can_focus">True</property>
+                                                    <property name="receives_default">True</property>
                                                     <signal name="clicked" handler="on_item_cat_orbs_add_clicked" swapped="no"/>
                                                     <child>
                                                       <object class="GtkImage">
                                                         <property name="visible">True</property>
-                                                        <property name="can-focus">False</property>
-                                                        <property name="icon-name">skytemple-list-add-symbolic</property>
+                                                        <property name="can_focus">False</property>
+                                                        <property name="icon_name">skytemple-list-add-symbolic</property>
                                                       </object>
                                                     </child>
                                                   </object>
@@ -4249,14 +4340,14 @@
                                                 <child>
                                                   <object class="GtkButton" id="item_cat_orbs_remove">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">True</property>
-                                                    <property name="receives-default">True</property>
+                                                    <property name="can_focus">True</property>
+                                                    <property name="receives_default">True</property>
                                                     <signal name="clicked" handler="on_item_cat_orbs_remove_clicked" swapped="no"/>
                                                     <child>
                                                       <object class="GtkImage">
                                                         <property name="visible">True</property>
-                                                        <property name="can-focus">False</property>
-                                                        <property name="icon-name">skytemple-list-remove-symbolic</property>
+                                                        <property name="can_focus">False</property>
+                                                        <property name="icon_name">skytemple-list-remove-symbolic</property>
                                                       </object>
                                                     </child>
                                                   </object>
@@ -4281,36 +4372,36 @@
                                         <child type="tab">
                                           <object class="GtkLabel">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">Orbs</property>
                                           </object>
                                           <packing>
                                             <property name="position">6</property>
-                                            <property name="tab-fill">False</property>
+                                            <property name="tab_fill">False</property>
                                           </packing>
                                         </child>
                                         <child>
                                           <object class="GtkBox">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
-                                            <property name="margin-bottom">5</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="margin_bottom">5</property>
                                             <property name="orientation">vertical</property>
                                             <property name="spacing">5</property>
                                             <child>
                                               <object class="GtkScrolledWindow">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">True</property>
-                                                <property name="shadow-type">in</property>
+                                                <property name="can_focus">True</property>
+                                                <property name="shadow_type">in</property>
                                                 <child>
                                                   <object class="GtkViewport">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">False</property>
+                                                    <property name="can_focus">False</property>
                                                     <child>
                                                       <object class="GtkTreeView" id="item_cat_others_tree">
                                                         <property name="visible">True</property>
-                                                        <property name="can-focus">True</property>
+                                                        <property name="can_focus">True</property>
                                                         <property name="model">item_cat_others_store</property>
-                                                        <property name="search-column">0</property>
+                                                        <property name="search_column">0</property>
                                                         <child internal-child="selection">
                                                           <object class="GtkTreeSelection"/>
                                                         </child>
@@ -4382,22 +4473,22 @@
                                             <child>
                                               <object class="GtkBox">
                                                 <property name="visible">True</property>
-                                                <property name="can-focus">False</property>
+                                                <property name="can_focus">False</property>
                                                 <property name="halign">end</property>
-                                                <property name="margin-right">5</property>
-                                                <property name="margin-end">5</property>
+                                                <property name="margin_right">5</property>
+                                                <property name="margin_end">5</property>
                                                 <property name="spacing">10</property>
                                                 <child>
                                                   <object class="GtkButton" id="item_cat_others_add">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">True</property>
-                                                    <property name="receives-default">True</property>
+                                                    <property name="can_focus">True</property>
+                                                    <property name="receives_default">True</property>
                                                     <signal name="clicked" handler="on_item_cat_others_add_clicked" swapped="no"/>
                                                     <child>
                                                       <object class="GtkImage">
                                                         <property name="visible">True</property>
-                                                        <property name="can-focus">False</property>
-                                                        <property name="icon-name">skytemple-list-add-symbolic</property>
+                                                        <property name="can_focus">False</property>
+                                                        <property name="icon_name">skytemple-list-add-symbolic</property>
                                                       </object>
                                                     </child>
                                                   </object>
@@ -4410,14 +4501,14 @@
                                                 <child>
                                                   <object class="GtkButton" id="item_cat_others_remove">
                                                     <property name="visible">True</property>
-                                                    <property name="can-focus">True</property>
-                                                    <property name="receives-default">True</property>
+                                                    <property name="can_focus">True</property>
+                                                    <property name="receives_default">True</property>
                                                     <signal name="clicked" handler="on_item_cat_others_remove_clicked" swapped="no"/>
                                                     <child>
                                                       <object class="GtkImage">
                                                         <property name="visible">True</property>
-                                                        <property name="can-focus">False</property>
-                                                        <property name="icon-name">skytemple-list-remove-symbolic</property>
+                                                        <property name="can_focus">False</property>
+                                                        <property name="icon_name">skytemple-list-remove-symbolic</property>
                                                       </object>
                                                     </child>
                                                   </object>
@@ -4442,12 +4533,12 @@
                                         <child type="tab">
                                           <object class="GtkLabel">
                                             <property name="visible">True</property>
-                                            <property name="can-focus">False</property>
+                                            <property name="can_focus">False</property>
                                             <property name="label" translatable="yes">Others</property>
                                           </object>
                                           <packing>
                                             <property name="position">7</property>
-                                            <property name="tab-fill">False</property>
+                                            <property name="tab_fill">False</property>
                                           </packing>
                                         </child>
                                       </object>
@@ -4457,8 +4548,8 @@
                                 <child type="label">
                                   <object class="GtkLabel">
                                     <property name="visible">True</property>
-                                    <property name="can-focus">False</property>
-                                    <property name="margin-bottom">5</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="margin_bottom">5</property>
                                     <property name="label" translatable="yes">Items</property>
                                   </object>
                                 </child>
@@ -4485,17 +4576,17 @@
             <child type="tab">
               <object class="GtkLabel">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Floor</property>
               </object>
               <packing>
-                <property name="tab-fill">False</property>
+                <property name="tab_fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <placeholder/>
@@ -4514,18 +4605,18 @@
             <child type="tab">
               <object class="GtkLabel">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Shop</property>
               </object>
               <packing>
                 <property name="position">1</property>
-                <property name="tab-fill">False</property>
+                <property name="tab_fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <placeholder/>
@@ -4544,18 +4635,18 @@
             <child type="tab">
               <object class="GtkLabel">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Monster House</property>
               </object>
               <packing>
                 <property name="position">2</property>
-                <property name="tab-fill">False</property>
+                <property name="tab_fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <placeholder/>
@@ -4574,18 +4665,18 @@
             <child type="tab">
               <object class="GtkLabel">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Buried</property>
               </object>
               <packing>
                 <property name="position">3</property>
-                <property name="tab-fill">False</property>
+                <property name="tab_fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <placeholder/>
@@ -4604,18 +4695,18 @@
             <child type="tab">
               <object class="GtkLabel">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Unk1</property>
               </object>
               <packing>
                 <property name="position">4</property>
-                <property name="tab-fill">False</property>
+                <property name="tab_fill">False</property>
               </packing>
             </child>
             <child>
               <object class="GtkBox">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="orientation">vertical</property>
                 <child>
                   <placeholder/>
@@ -4634,12 +4725,12 @@
             <child type="tab">
               <object class="GtkLabel">
                 <property name="visible">True</property>
-                <property name="can-focus">False</property>
+                <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Unk2</property>
               </object>
               <packing>
                 <property name="position">5</property>
-                <property name="tab-fill">False</property>
+                <property name="tab_fill">False</property>
               </packing>
             </child>
           </object>
@@ -4650,12 +4741,12 @@
         <child type="tab">
           <object class="GtkLabel">
             <property name="visible">True</property>
-            <property name="can-focus">False</property>
+            <property name="can_focus">False</property>
             <property name="label" translatable="yes">Items</property>
           </object>
           <packing>
             <property name="position">3</property>
-            <property name="tab-fill">False</property>
+            <property name="tab_fill">False</property>
           </packing>
         </child>
       </object>

--- a/skytemple/module/dungeon/controller/floor.py
+++ b/skytemple/module/dungeon/controller/floor.py
@@ -90,6 +90,43 @@ class FloorEditItemList(Enum):
     UNK1 = 4
     UNK2 = 5
 
+# TODO: Multi-language support for this
+class FloorRanks(Enum):
+    INVALID = 0, "Invalid"
+    E_RANK = 1, "E Rank"
+    D_RANK = 2, "D Rank"
+    C_RANK = 3, "C Rank"
+    B_RANK = 4, "B Rank"
+    A_RANK = 5, "A Rank"
+    S_RANK = 6, "S Rank"
+    S1_RANK = 7, "★1 Rank"
+    S2_RANK = 8, "★2 Rank"
+    S3_RANK = 9, "★3 Rank"
+    S4_RANK = 10, "★4 Rank"
+    S5_RANK = 11, "★5 Rank"
+    S6_RANK = 12, "★6 Rank"
+    S7_RANK = 13, "★7 Rank"
+    S8_RANK = 14, "★8 Rank"
+    S9_RANK = 15, "★9 Rank"
+
+    def __new__(cls, *args, **kwargs):
+        obj = object.__new__(cls)
+        obj._value_ = args[0]
+        return obj
+
+    # ignore the first param since it's already set by __new__
+    def __init__(self, _: str, print_name: str = None):
+        self._print_name_ = print_name
+
+    def __str__(self):
+        return self._print_name_
+
+    def __repr__(self):
+        return f'FloorRanks.{self.name}'
+
+    @property
+    def print_name(self):
+        return self._print_name_
 
 class FloorController(AbstractController):
     _last_open_tab_id = 0
@@ -158,6 +195,27 @@ class FloorController(AbstractController):
     def on_btn_preview_clicked(self, *args):
         pass  # todo
 
+    def on_cb_floor_ranks_changed(self, w, *args):
+        if self.module.has_floor_ranks():
+            cb = self.builder.get_object('cb_floor_ranks')
+            self.module.set_floor_rank(self.item.dungeon.dungeon_id, self.item.floor_id, cb.get_active())
+            self.mark_as_modified()
+
+    def on_btn_help_floor_ranks_clicked(self, *args):
+        self._help("This attribute is the base rank of this floor. \n"
+                   "The floor rank determines the item list used for mission rewards and treasure boxes content. \n"
+                   "Needs the 'ExtractDungeonData' patch to be applied to edit this attribute.")
+        
+    def on_cb_mission_forbidden_changed(self, w, *args):
+        if self.module.has_floor_ranks():
+            cb = self.builder.get_object('cb_mission_forbidden')
+            self.module.set_floor_mf(self.item.dungeon.dungeon_id, self.item.floor_id, cb.get_active())
+            self.mark_as_modified()
+            
+    def on_btn_help_mission_forbidden_clicked(self, *args):
+        self._help("If this attribute is set to 'Yes', no missions will be generated for this floor, and Wonder Mail S codes targetting this floor will be considered as invalid. \n"
+                   "Needs the 'ExtractDungeonData' patch to be applied to edit this attribute.")
+        
     def on_cb_tileset_id_changed(self, w, *args):
         self._update_from_widget(w)
         self.mark_as_modified(modified_mappag=True)
@@ -765,6 +823,7 @@ class FloorController(AbstractController):
                    "All spawn entries are always saved to the game sorted by their (Pokémon, item, trap) ID.")
 
     def on_btn_export_clicked(self, *args):
+        # TODO: Add export for Ranks and Forbidden Missions attributes
         from skytemple.module.dungeon.module import DungeonGroup, ICON_GROUP, \
             ICON_DUNGEONS, DOJO_DUNGEONS_FIRST, DOJO_DUNGEONS_LAST
         dialog: Gtk.Dialog = self.builder.get_object('export_dialog')
@@ -855,6 +914,8 @@ class FloorController(AbstractController):
             self.module.import_from_xml(selected_floors, xml)
 
     def on_btn_import_clicked(self, *args):
+        # TODO: Add import for Ranks and Forbidden Missions attributes
+        
         save_diag = Gtk.FileChooserNative.new(
             "Import floor from...",
             SkyTempleMainController.window(),
@@ -967,8 +1028,24 @@ class FloorController(AbstractController):
         self._comboxbox_for_music_id(['cb_music_id'])
         # cb_fixed_floor_id
         self._comboxbox_for_fixed_floor_id(['cb_fixed_floor_id'])
+        if self.module.has_floor_ranks():
+            # cb_floor_ranks
+            self._comboxbox_for_enum(['cb_floor_ranks'], FloorRanks)
+        else:
+            self.builder.get_object('cb_floor_ranks').set_sensitive(False)
+        if self.module.has_mission_forbidden():
+            # cb_mission_forbidden
+            self._comboxbox_for_boolean(['cb_mission_forbidden'])
+        else:
+            self.builder.get_object('cb_mission_forbidden').set_sensitive(False)
 
     def _init_layout_values(self):
+        if self.module.has_floor_ranks():
+            cb = self.builder.get_object('cb_floor_ranks')
+            cb.set_active(self.module.get_floor_rank(self.item.dungeon.dungeon_id, self.item.floor_id))
+        if self.module.has_mission_forbidden():
+            cb = self.builder.get_object('cb_mission_forbidden')
+            cb.set_active(self.module.get_floor_mf(self.item.dungeon.dungeon_id, self.item.floor_id))
         all_entries_and_cbs = [
             "cb_tileset_id",
             "cb_music_id",

--- a/skytemple/module/dungeon/module.py
+++ b/skytemple/module/dungeon/module.py
@@ -55,6 +55,7 @@ from skytemple_files.graphics.dpc.model import Dpc
 from skytemple_files.graphics.dpci.model import Dpci
 from skytemple_files.graphics.dpl.model import Dpl
 from skytemple_files.hardcoded.dungeons import HardcodedDungeons, DungeonDefinition, DungeonRestriction
+from skytemple_files.dungeon_data.floor_attribute.handler import FloorAttributeHandler
 
 # TODO: Add this to dungeondata.xml?
 from skytemple_files.hardcoded.fixed_floor import EntitySpawnEntry, ItemSpawn, MonsterSpawn, TileSpawn, \
@@ -74,7 +75,8 @@ MAPPAG_PATH = 'BALANCE/mappa_gs.bin'
 FIXED_PATH = 'BALANCE/fixed.bin'
 DUNGEON_BIN = 'DUNGEON/dungeon.bin'
 logger = logging.getLogger(__name__)
-
+FLOOR_RANKS = "BALANCE/f_ranks.bin"
+FLOOR_MISSION_FORBIDDEN = "BALANCE/fforbid.bin"
 
 class DungeonViewInfo:
     def __init__(self, dungeon_id: int, length_can_be_edited: bool):
@@ -118,6 +120,7 @@ class DungeonModule(AbstractModule):
         self._fixed_floor_root_iter = None
         self._fixed_floor_data: Optional[FixedBin] = None
         self._dungeon_bin: Optional[DungeonBinPack] = None
+        self._cached_dungeon_list = None
 
         # Preload mappa
         self.get_mappa()
@@ -230,10 +233,11 @@ class DungeonModule(AbstractModule):
         recursive_up_item_store_mark_as_modified(row)
 
     def get_dungeon_list(self) -> List[DungeonDefinition]:
-        # TODO: Cache?
-        return HardcodedDungeons.get_dungeon_list(
-            self.project.get_binary(BinaryName.ARM9), self.project.get_rom_module().get_static_data()
-        )
+        if self._cached_dungeon_list==None:
+            self._cached_dungeon_list = HardcodedDungeons.get_dungeon_list(
+                self.project.get_binary(BinaryName.ARM9), self.project.get_rom_module().get_static_data()
+            )
+        return self._cached_dungeon_list
 
     def get_dungeon_restrictions(self) -> List[DungeonRestriction]:
         # TODO: Cache?
@@ -259,6 +263,7 @@ class DungeonModule(AbstractModule):
         self.project.modify_binary(BinaryName.ARM9, lambda binary: HardcodedDungeons.set_dungeon_list(
             dungeons, binary, self.project.get_rom_module().get_static_data()
         ))
+        self._cached_dungeon_list = None
 
     def update_dungeon_restrictions(self, dungeon_id: int, restrictions: DungeonRestriction):
         all_restrictions = self.get_dungeon_restrictions()
@@ -281,7 +286,7 @@ class DungeonModule(AbstractModule):
         root = self._root_iter
 
         # Regular dungeons
-        for dungeon_or_group in self.load_dungeons():
+        for group_id, dungeon_or_group in enumerate(self.load_dungeons()):
             if isinstance(dungeon_or_group, DungeonGroup):
                 # Group
                 group = item_store.append(root, [
@@ -339,11 +344,13 @@ class DungeonModule(AbstractModule):
             if dungeon.mappa_index not in groups:
                 groups[dungeon.mappa_index] = []
             groups[dungeon.mappa_index].append(idx)
+            self.adjust_nb_floors_mf(dungeon.mappa_index, dungeon.number_floors_in_group)
+            self.adjust_nb_floors_ranks(dungeon.mappa_index, dungeon.number_floors_in_group)
         groups_sorted = {}
         for idx, entries in groups.items():
             groups_sorted[idx] = sorted(entries, key=lambda dun_idx: lst[dun_idx].start_after)
         groups = groups_sorted
-
+        
         for idx, dungeon in enumerate(lst):
             if dungeon.mappa_index not in yielded:
                 yielded.add(dungeon.mappa_index)
@@ -369,6 +376,7 @@ class DungeonModule(AbstractModule):
         """
         mappa = self.get_mappa()
         old_floor_lists = mappa.floor_lists
+        reorder_list = []
         dojo_floors = old_floor_lists[DOJO_MAPPA_ENTRY]
         new_floor_lists = []
         dungeons = self.get_dungeon_list()
@@ -380,6 +388,8 @@ class DungeonModule(AbstractModule):
             # At DOJO_MAPPA_ENTRY insert the dojo:
             if len(new_floor_lists) == DOJO_MAPPA_ENTRY:
                 new_floor_lists.append(dojo_floors)
+                reorder_list.append([(DOJO_MAPPA_ENTRY, None, None)])
+            reorder_list.append([])
             # Process this entry
             next_index = len(new_floor_lists)
             new_floor_list = []
@@ -393,6 +403,7 @@ class DungeonModule(AbstractModule):
                 old_first = dungeons[i].start_after
                 old_last = old_first + dungeons[i].number_floors
                 new_floors = old_floor_lists[dungeons[i].mappa_index][old_first:old_last]
+                reorder_list[-1].append((dungeons[i].mappa_index, old_first, old_last))
                 floor_i = len(new_floor_list)
                 for floor in new_floors:
                     floor.layout.floor_number = floor_i
@@ -411,14 +422,25 @@ class DungeonModule(AbstractModule):
             for i in range(len(new_floor_lists), DOJO_MAPPA_ENTRY + 1):
                 if i == DOJO_MAPPA_ENTRY:
                     new_floor_lists.append(dojo_floors)
+                    reorder_list.append([(DOJO_MAPPA_ENTRY, None, None)])
                 else:
                     new_floor_lists.append([])
-
+                    reorder_list.append([])
+        
         mappa.floor_lists = new_floor_lists
         self._validator.floors = new_floor_lists
         self.mark_root_as_modified()
         self.save_mappa()
         self.save_dungeon_list(dungeons)
+
+        # Update floor attributes
+        self.reorder_floors_ranks(reorder_list)
+        self.reorder_floors_mf(reorder_list)
+        if self.has_floor_ranks():
+            self.project.mark_as_modified(FLOOR_RANKS)
+        if self.has_mission_forbidden():
+            self.project.mark_as_modified(FLOOR_MISSION_FORBIDDEN)
+
         self.rebuild_dungeon_tree()
 
     def generate_group_label(self, base_dungeon_id) -> str:
@@ -451,7 +473,7 @@ class DungeonModule(AbstractModule):
             return 0x30
         return self.get_dungeon_list()[idx].number_floors
 
-    def change_floor_count(self, dungeon_id, number_floors_new):
+    def change_floor_count(self, dungeon_id, number_floors_new): #TODO: Unchanged
         """
         This will update the floor count for the given dungeon:
         - Will add or remove floors from the dungeon's mappa entry, starting at the end of this dungeon's floor
@@ -476,7 +498,6 @@ class DungeonModule(AbstractModule):
         floor_offset = dungeon_definitions[dungeon_id].start_after
         number_floors_old = dungeon_definitions[dungeon_id].number_floors
         floor_list = self.get_mappa().floor_lists[mappa_index]
-
         floors_added = number_floors_new - number_floors_old
 
         # Update Mappa
@@ -491,6 +512,15 @@ class DungeonModule(AbstractModule):
             last_floor_xml = floor_list[floor_offset + number_floors_old - 1].to_xml()
             for i in range(0, floors_added):
                 floor_list.insert(floor_offset + number_floors_old + i, MappaFloor.from_xml(last_floor_xml))
+
+        # Update floor ranks
+        self.extend_nb_floors_ranks(dungeon_id, floor_offset+number_floors_old, floors_added, self.get_floor_rank(dungeon_id, floor_offset+number_floors_old-1))
+        if self.has_floor_ranks():
+            self.project.mark_as_modified(FLOOR_RANKS)
+        # Update mission forbidden
+        self.extend_nb_floors_mf(dungeon_id, floor_offset+number_floors_old, floors_added, self.get_floor_mf(dungeon_id, floor_offset+number_floors_old-1))
+        if self.has_mission_forbidden():
+            self.project.mark_as_modified(FLOOR_MISSION_FORBIDDEN)
 
         # Update dungeon data
         dungeon_definitions[dungeon_id].number_floors = number_floors_new
@@ -546,6 +576,77 @@ class DungeonModule(AbstractModule):
             self._dungeon_bin.get(f'dungeon_bg{background_id}.dpl'),
         )
 
+    def _get_dungeon_group(self, dungeon_id: int) -> int:
+        return self.get_dungeon_list()[dungeon_id].mappa_index
+    
+    def has_mission_forbidden(self):
+        return self.project.file_exists(FLOOR_MISSION_FORBIDDEN)
+    
+    def has_floor_ranks(self):
+        return self.project.file_exists(FLOOR_RANKS)
+
+    def extend_nb_floors_ranks(self, dungeon_id: int, start_floor: int, nb_floors: int, rank: int = 0):
+        if self.has_floor_ranks():
+            group_id = self._get_dungeon_group(dungeon_id)
+            f_ranks = self.project.open_file_in_rom(FLOOR_RANKS, FloorAttributeHandler)
+            f_ranks.extend_nb_floors(group_id, start_floor+1, nb_floors, rank)
+        
+    def reorder_floors_ranks(self, reorder_list: List[List[Tuple[int,Optional[int],Optional[int]]]]): # (old_group_id, start_floor, end_floor)
+        if self.has_floor_ranks():
+            f_ranks = self.project.open_file_in_rom(FLOOR_RANKS, FloorAttributeHandler)
+            f_ranks.reorder_floors(reorder_list)
+        
+    def adjust_nb_floors_ranks(self, group_id: int, nb_floors: int):
+        if self.has_floor_ranks():
+            f_ranks = self.project.open_file_in_rom(FLOOR_RANKS, FloorAttributeHandler)
+            f_ranks.adjust_nb_floors(group_id, nb_floors+1)
+        
+    def get_floor_rank(self, dungeon_id: int, floor_id: int) -> Optional[int]:
+        if self.has_floor_ranks():
+            group_id = self._get_dungeon_group(dungeon_id)
+            f_ranks = self.project.open_file_in_rom(FLOOR_RANKS, FloorAttributeHandler)
+            return f_ranks.get_floor_attr(group_id, floor_id+1)
+        else:
+            return None
+
+    def set_floor_rank(self, dungeon_id: int, floor_id: int, rank: int):
+        if self.has_floor_ranks():
+            group_id = self._get_dungeon_group(dungeon_id)
+            f_ranks = self.project.open_file_in_rom(FLOOR_RANKS, FloorAttributeHandler)
+            f_ranks.set_floor_attr(group_id, floor_id+1, rank)
+            self.project.mark_as_modified(FLOOR_RANKS)
+    
+    def extend_nb_floors_mf(self, dungeon_id: int, start_floor: int, nb_floors: int, forbidden: int):
+        if self.has_mission_forbidden():
+            group_id = self._get_dungeon_group(dungeon_id)
+            f_mission = self.project.open_file_in_rom(FLOOR_MISSION_FORBIDDEN, FloorAttributeHandler)
+            f_mission.extend_nb_floors(group_id, start_floor+1, nb_floors, forbidden)
+        
+    def reorder_floors_mf(self, reorder_list: List[List[Tuple[int,Optional[int],Optional[int]]]]): # (old_group_id, start_floor, end_floor)
+        if self.has_floor_ranks():
+            f_mission = self.project.open_file_in_rom(FLOOR_MISSION_FORBIDDEN, FloorAttributeHandler)
+            f_mission.reorder_floors(reorder_list)
+            
+    def adjust_nb_floors_mf(self, group_id: int, nb_floors: int):
+        if self.has_mission_forbidden():
+            f_mission = self.project.open_file_in_rom(FLOOR_MISSION_FORBIDDEN, FloorAttributeHandler)
+            f_mission.adjust_nb_floors(group_id, nb_floors+1)
+        
+    def get_floor_mf(self, dungeon_id: int, floor_id: int) -> Optional[int]:
+        if self.has_mission_forbidden():
+            group_id = self._get_dungeon_group(dungeon_id)
+            f_mission = self.project.open_file_in_rom(FLOOR_MISSION_FORBIDDEN, FloorAttributeHandler)
+            return f_mission.get_floor_attr(group_id, floor_id+1)
+        else:
+            return None
+
+    def set_floor_mf(self, dungeon_id: int, floor_id: int, forbidden: int):
+        if self.has_mission_forbidden():
+            group_id = self._get_dungeon_group(dungeon_id)
+            f_mission = self.project.open_file_in_rom(FLOOR_MISSION_FORBIDDEN, FloorAttributeHandler)
+            f_mission.set_floor_attr(group_id, floor_id+1, forbidden)
+            self.project.mark_as_modified(FLOOR_MISSION_FORBIDDEN)
+    
     def get_fixed_floor_entity_lists(self) -> Tuple[List[EntitySpawnEntry], List[ItemSpawn], List[MonsterSpawn], List[TileSpawn], List[MonsterSpawnStats]]:
         config = self.project.get_rom_module().get_static_data()
         ov29 = self.project.get_binary(BinaryName.OVERLAY_29)


### PR DESCRIPTION
See SkyTemple/skytemple-files#73
Adds UI support for editing ranks and no missions floor attributes (currently import/export is not supported for those attributes).
Some things have to be changed in order to provide multilanguage support (like the enumeration for the floor ranks).