### PR TITLE
Extend the Number of Pokémon entries

### DIFF
--- a/skytemple/core/events/impl/discord.py
+++ b/skytemple/core/events/impl/discord.py
@@ -34,7 +34,7 @@ import time
 
 from skytemple.core.string_provider import StringType
 from skytemple.core.ui_utils import version
-from skytemple_files.data.md.model import NUM_ENTITIES
+from skytemple_files.data.md.model import MdProperties
 
 CLIENT_ID = "736538698719690814"
 IDLE_TIMEOUT = 5 * 60
@@ -224,7 +224,7 @@ class DiscordPresence(AbstractListener):
         self.module_state = self.rom_name
         if isinstance(controller, MonsterController):
             self.module_state = module.project.get_string_provider().get_value(
-                StringType.POKEMON_NAMES, controller.item_id % NUM_ENTITIES
+                StringType.POKEMON_NAMES, controller.item_id % MdProperties.NUM_ENTITIES
             )
 
     def on_view_switch__StringsModule(self, module: AbstractModule, controller: AbstractController, breadcrumbs: List[str]):

--- a/skytemple/core/string_provider.py
+++ b/skytemple/core/string_provider.py
@@ -72,6 +72,9 @@ class StringType(Enum):
     @property
     def xml_name(self):
         return self._xml_name_
+    
+    def replace_xml_name(self, new_name):
+        self._xml_name_ = new_name
 
 
 LanguageLike = Union[str, Pmd2Language]  # locale string or Pmd2Language
@@ -121,7 +124,7 @@ class StringProvider:
         Returns the string table model for the given language.
         If language is not set, the default ROM language is used.
         """
-        return self.project.open_file_in_rom(f'{MESSAGE_DIR}/{self._get_language(language).filename}', FileType.STR)
+        return self.project.open_file_in_rom(f'{MESSAGE_DIR}/{self.get_language(language).filename}', FileType.STR)
 
     def get_languages(self) -> List[Pmd2Language]:
         """Returns all supported languages."""
@@ -133,7 +136,7 @@ class StringProvider:
             if self.project.is_opened(fname):
                 self.project.mark_as_modified(fname)
 
-    def _get_language(self, language_locale: LanguageLike = None) -> Pmd2Language:
+    def get_language(self, language_locale: LanguageLike = None) -> Pmd2Language:
         if isinstance(language_locale, Pmd2Language):
             return language_locale
 

--- a/skytemple/module/dungeon/controller/fixed.py
+++ b/skytemple/module/dungeon/controller/fixed.py
@@ -32,7 +32,7 @@ from skytemple.module.dungeon.entity_rule_container import EntityRuleContainer
 from skytemple.module.dungeon.fixed_room_drawer import FixedRoomDrawer, InfoLayer, InteractionMode
 from skytemple.module.dungeon.fixed_room_tileset_renderer.bg import FixedFloorDrawerBackground
 from skytemple.module.dungeon.fixed_room_tileset_renderer.tileset import FixedFloorDrawerTileset
-from skytemple_files.data.md.model import NUM_ENTITIES
+from skytemple_files.data.md.model import MdProperties
 from skytemple_files.dungeon_data.fixed_bin.model import FixedFloor, TileRuleType, TileRule, EntityRule
 from skytemple_files.graphics.dpc.model import DPC_TILING_DIM
 from skytemple_files.graphics.dpci.model import DPCI_TILE_DIM
@@ -77,7 +77,7 @@ class FixedController(AbstractController):
         self.long_monster_names = {}
         length = len(self.module.get_monster_md().entries)
         for i, entry in enumerate(self.module.get_monster_md().entries):
-            name = self.module.project.get_string_provider().get_value(StringType.POKEMON_NAMES, i % NUM_ENTITIES)
+            name = self.module.project.get_string_provider().get_value(StringType.POKEMON_NAMES, i % MdProperties.NUM_ENTITIES)
             self.monster_names[i] = f'{name}'
             self.long_monster_names[i] = f'{name} ({entry.gender.name.capitalize()}) (${i:04})'
         for i in range(length, length + SPECIAL_MONSTERS):

--- a/skytemple/module/dungeon/controller/fixed_rooms.py
+++ b/skytemple/module/dungeon/controller/fixed_rooms.py
@@ -23,7 +23,7 @@ from gi.repository.Gtk import Widget
 from skytemple.core.module_controller import AbstractController
 from skytemple.core.string_provider import StringType
 from skytemple.module.dungeon import MAX_ITEMS, SPECIAL_ITEMS, SPECIAL_MONSTERS
-from skytemple_files.data.md.model import NUM_ENTITIES
+from skytemple_files.data.md.model import MdProperties
 from skytemple_files.dungeon_data.fixed_bin.model import TileRuleType
 from skytemple_files.dungeon_data.mappa_bin.trap_list import MappaTrapType
 from skytemple_files.hardcoded.fixed_floor import MonsterSpawnType
@@ -53,7 +53,7 @@ class FixedRoomsController(AbstractController):
         self.monster_names = {}
         length = len(self.module.get_monster_md().entries)
         for i, entry in enumerate(self.module.get_monster_md().entries):
-            name = self.module.project.get_string_provider().get_value(StringType.POKEMON_NAMES, i % NUM_ENTITIES)
+            name = self.module.project.get_string_provider().get_value(StringType.POKEMON_NAMES, i % MdProperties.NUM_ENTITIES)
             self.monster_names[i] = f'{name} ({entry.gender.print_name}) (${i:04})'
         for i in range(length, length + SPECIAL_MONSTERS):
             self.monster_names[i] = _('(Special?)') + f' (${i:04})'

--- a/skytemple/module/dungeon/controller/floor.glade
+++ b/skytemple/module/dungeon/controller/floor.glade
@@ -2852,6 +2852,18 @@
                       </packing>
                     </child>
                     <child>
+                      <object class="GtkLabel" id="label_kecleon_gender">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes">Female</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">4</property>
+                      </packing>
+                    </child>
+                    <child>
                       <object class="GtkButton" id="monster_spawns_remove">
                         <property name="visible">True</property>
                         <property name="can-focus">True</property>
@@ -2869,6 +2881,18 @@
                         <property name="expand">False</property>
                         <property name="fill">True</property>
                         <property name="pack-type">end</property>
+                        <property name="position">4</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkSwitch" id="switch_kecleon_gender">
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <signal name="state-set" handler="on_switch_kecleon_gender_state_set" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
                         <property name="position">4</property>
                       </packing>
                     </child>

--- a/skytemple/module/dungeon/controller/floor.py
+++ b/skytemple/module/dungeon/controller/floor.py
@@ -426,10 +426,10 @@ class FloorController(AbstractController):
         except ValueError:
             return
 
-        if entid == KECLEON_MD_INDEX or entid >= DUMMY_MD_INDEX:
+        if entid == KECLEON_MD_INDEX:
             display_error(
                 None,
-                f(_("You can not spawn Kecleons or the Decoy Pokémon or any Pokémon above #{DUMMY_MD_INDEX}.")),
+                f(_("You can not spawn Kecleons or the Decoy Pokémon.")),
                 _("SkyTemple: Invalid Pokémon")
             )
             return
@@ -1131,7 +1131,7 @@ class FloorController(AbstractController):
     def _init_monster_completion_store(self):
         monster_md = self.module.get_monster_md()
         monster_store: Gtk.ListStore = self.builder.get_object('completion_monsters_store')
-        for idx, entry in enumerate(monster_md.entries[0:DUMMY_MD_INDEX]):
+        for idx, entry in enumerate(monster_md.entries):
             if idx == 0:
                 continue
             name = self.module.project.get_string_provider().get_value(StringType.POKEMON_NAMES, entry.md_index_base)

--- a/skytemple/module/dungeon/controller/floor.py
+++ b/skytemple/module/dungeon/controller/floor.py
@@ -51,7 +51,7 @@ if TYPE_CHECKING:
 
 COUNT_VALID_BGM = 118
 COUNT_VALID_FIXED_FLOORS = 256
-KECLEON_MD_INDEX = 383
+KECLEON_MD_INDEX = [383, 983]
 CB = 'cb_'
 CB_TERRAIN_SETTINGS = 'cb_terrain_settings__'
 ENTRY = 'entry_'
@@ -177,6 +177,9 @@ class FloorController(AbstractController):
         self._recalculate_spawn_chances('item_cat_orbs_store', 4, 3)
         self._recalculate_spawn_chances('item_cat_others_store', 4, 3)
 
+        if not self.module.project.is_patch_applied("ExpandPokeList"):
+            self.builder.get_object('switch_kecleon_gender').destroy()
+            self.builder.get_object('label_kecleon_gender').destroy()
         self._init_layout_values()
         self._loading = False
 
@@ -426,7 +429,7 @@ class FloorController(AbstractController):
         except ValueError:
             return
 
-        if entid == KECLEON_MD_INDEX:
+        if entid in KECLEON_MD_INDEX or entid==DUMMY_MD_INDEX:
             display_error(
                 None,
                 f(_("You can not spawn Kecleons or the Decoy Pokémon.")),
@@ -488,11 +491,21 @@ class FloorController(AbstractController):
         except:
             return
         for i, monster in enumerate(self.entry.monsters):
-            if monster.md_index == KECLEON_MD_INDEX:
+            if monster.md_index in KECLEON_MD_INDEX:
                 monster.level = level
                 break
         self.mark_as_modified()
 
+    def on_switch_kecleon_gender_state_set(self, w, *args):
+        if w.get_active():
+            new_index = KECLEON_MD_INDEX[1]
+        else:
+            new_index = KECLEON_MD_INDEX[0]
+        for i, monster in enumerate(self.entry.monsters):
+            if monster.md_index in KECLEON_MD_INDEX:
+                monster.md_index = new_index
+                break
+        self.mark_as_modified()
     # </editor-fold>
 
     # <editor-fold desc="HANDLERS TRAPS" defaultstate="collapsed">
@@ -1118,8 +1131,13 @@ class FloorController(AbstractController):
         for i, monster in enumerate(self.entry.monsters):
             relative_weight = relative_weights[i]
             chance = f'{int(relative_weight) / sum_of_all_weights * 100:.3f}%'
-            if monster.md_index == KECLEON_MD_INDEX:
+            if monster.md_index in KECLEON_MD_INDEX:
                 self.builder.get_object('kecleon_level_entry').set_text(str(monster.level))
+                switch = self.builder.get_object('switch_kecleon_gender')
+                if monster.md_index==KECLEON_MD_INDEX[0]:
+                    switch.set_active(False)
+                else:
+                    switch.set_active(True)
                 continue
             if monster.md_index == DUMMY_MD_INDEX:
                 continue
@@ -1327,15 +1345,17 @@ class FloorController(AbstractController):
     def _save_monster_spawn_rates(self):
         store: Gtk.ListStore = self.builder.get_object('monster_spawns_store')
         original_kecleon_level = 0
+        original_kecleon_index = KECLEON_MD_INDEX[0]
         for monster in self.entry.monsters:
-            if monster.md_index == KECLEON_MD_INDEX:
+            if monster.md_index in KECLEON_MD_INDEX:
+                original_kecleon_index = monster.md_index
                 original_kecleon_level = monster.level
                 break
         self.entry.monsters = []
         rows = []
         for row in store:
             rows.append(row[:])
-        rows.append([KECLEON_MD_INDEX, None, None, str(original_kecleon_level), None, "0"])
+        rows.append([original_kecleon_index, None, None, str(original_kecleon_level), None, "0"])
         rows.append([DUMMY_MD_INDEX, None, None, "1", None, "0"])
         rows.sort(key=lambda e: e[0])
 

--- a/skytemple/module/monster/controller/monster.glade
+++ b/skytemple/module/monster/controller/monster.glade
@@ -2755,7 +2755,7 @@ If you choose to export both genders, upon import the matching gender entry will
                         <property name="row-spacing">5</property>
                         <property name="column-spacing">5</property>
                         <child>
-                          <object class="GtkLabel">
+                          <object class="GtkLabel" id="lbl_unk_1_0">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
                             <property name="halign">end</property>
@@ -2816,7 +2816,7 @@ If you choose to export both genders, upon import the matching gender entry will
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkLabel">
+                          <object class="GtkLabel" id="lbl_unk_17">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
                             <property name="halign">end</property>
@@ -2841,7 +2841,7 @@ If you choose to export both genders, upon import the matching gender entry will
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkLabel">
+                          <object class="GtkLabel" id="lbl_unk_18">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
                             <property name="halign">end</property>
@@ -2960,7 +2960,7 @@ If you choose to export both genders, upon import the matching gender entry will
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkLabel">
+                          <object class="GtkLabel" id="lbl_unk_1_1">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
                             <property name="halign">end</property>
@@ -2972,7 +2972,7 @@ If you choose to export both genders, upon import the matching gender entry will
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkLabel">
+                          <object class="GtkLabel" id="lbl_unk_1_2">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
                             <property name="halign">end</property>
@@ -2984,7 +2984,7 @@ If you choose to export both genders, upon import the matching gender entry will
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkLabel">
+                          <object class="GtkLabel" id="lbl_unk_1_3">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
                             <property name="halign">end</property>

--- a/skytemple/module/monster/controller/monster.glade
+++ b/skytemple/module/monster/controller/monster.glade
@@ -796,7 +796,6 @@ If you choose to export both genders, upon import the matching gender entry will
           <packing>
             <property name="left-attach">1</property>
             <property name="top-attach">3</property>
-            <property name="width">2</property>
           </packing>
         </child>
         <child>
@@ -915,6 +914,27 @@ If you choose to export both genders, upon import the matching gender entry will
             <property name="left-attach">0</property>
             <property name="top-attach">8</property>
             <property name="width">3</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkButton" id="btn_help_entid">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">True</property>
+            <property name="halign">start</property>
+            <property name="valign">center</property>
+            <signal name="clicked" handler="on_btn_help_entid_clicked" swapped="no"/>
+            <child>
+              <object class="GtkImage">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="icon-name">skytemple-help-about-symbolic</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="left-attach">2</property>
+            <property name="top-attach">3</property>
           </packing>
         </child>
         <style>
@@ -2074,6 +2094,9 @@ If you choose to export both genders, upon import the matching gender entry will
                                                 <property name="vexpand">True</property>
                                                 <property name="model">egg_store</property>
                                                 <property name="search-column">0</property>
+                                                <child internal-child="selection">
+                                                  <object class="GtkTreeSelection"/>
+                                                </child>
                                                 <child>
                                                   <object class="GtkTreeViewColumn">
                                                     <property name="title" translatable="yes">ID</property>
@@ -2210,6 +2233,9 @@ If you choose to export both genders, upon import the matching gender entry will
                                                 <property name="vexpand">True</property>
                                                 <property name="model">evo_store</property>
                                                 <property name="search-column">0</property>
+                                                <child internal-child="selection">
+                                                  <object class="GtkTreeSelection"/>
+                                                </child>
                                                 <child>
                                                   <object class="GtkTreeViewColumn">
                                                     <property name="title" translatable="yes">ID</property>

--- a/skytemple/module/monster/controller/monster.py
+++ b/skytemple/module/monster/controller/monster.py
@@ -1178,16 +1178,16 @@ Each drop type x has a chance of (x rate)/(sum of all the rates) to be selected.
             if self.module.project.is_patch_applied("ExpandPokeList"):
                 check_value = self.entry.unk17
                 check_value_file = self.entry.unk18
+                max_tile_slots_needed, max_file_size_needed = self._get_sprite_properties(self.entry)
             else:
                 sprite_size_table = self.module.get_pokemon_sprite_data_table()
                 check_value = sprite_size_table[md_gender1.md_index_base].sprite_tile_slots
                 check_value_file = sprite_size_table[md_gender1.md_index_base].unk1
-            
-            max_tile_slots_needed, max_file_size_needed = self._get_sprite_properties(md_gender1)
-            if md_gender2!=None:
-                max_tile_slots_needed2, max_file_size_needed2 = self._get_sprite_properties(md_gender2)
-                max_tile_slots_needed = max(max_tile_slots_needed, max_tile_slots_needed2)
-                max_file_size_needed = max(max_file_size_needed, max_file_size_needed2)
+                max_tile_slots_needed, max_file_size_needed = self._get_sprite_properties(md_gender1)
+                if md_gender2!=None:
+                    max_tile_slots_needed2, max_file_size_needed2 = self._get_sprite_properties(md_gender2)
+                    max_tile_slots_needed = max(max_tile_slots_needed, max_tile_slots_needed2)
+                    max_file_size_needed = max(max_file_size_needed, max_file_size_needed2)
             if check_value != max_tile_slots_needed:
                 if self.module.project.is_patch_applied("ExpandPokeList"):
                     self.entry.unk17 = max_tile_slots_needed
@@ -1239,9 +1239,9 @@ Each drop type x has a chance of (x rate)/(sum of all the rates) to be selected.
             if idx == 0:
                 continue
             if not self.module.project.is_patch_applied('ExpandPokeList'):
-                sidx = self.entry.md_index_base
+                sidx = entry.md_index_base
             else:
-                sidx = self.entry.md_index
+                sidx = entry.md_index
             name = self.module.project.get_string_provider().get_value(StringType.POKEMON_NAMES, sidx)
             self._ent_names[idx] = f'{name} ({entry.gender.print_name}) (#{idx:04})'
             monster_store.append([self._ent_names[idx]])

--- a/skytemple/module/monster/controller/monster.py
+++ b/skytemple/module/monster/controller/monster.py
@@ -186,7 +186,7 @@ class MonsterController(AbstractController):
         self._update_from_entry(w)
         self.mark_as_modified()
         self._sprite_provider.reset()
-        self._check_sprite_size(False)
+        #self._check_sprite_size(False)
         self.builder.get_object('draw_sprite').queue_draw()
         self._reload_sprite_page()
 

--- a/skytemple/module/monster/controller/monster.py
+++ b/skytemple/module/monster/controller/monster.py
@@ -651,9 +651,9 @@ Each drop type x has a chance of (x rate)/(sum of all the rates) to be selected.
         store.clear()
         monster_entries_by_base_id: Dict[int, List[MdEntry]] = {}
         for entry in self.module.monster_md.entries:
-            if entry.md_index_base not in monster_entries_by_base_id:
-                monster_entries_by_base_id[entry.md_index_base] = []
-            monster_entries_by_base_id[entry.md_index_base].append(entry)
+            if getattr(entry, self.module.effective_base_attr) not in monster_entries_by_base_id:
+                monster_entries_by_base_id[getattr(entry, self.module.effective_base_attr)] = []
+            monster_entries_by_base_id[getattr(entry, self.module.effective_base_attr)].append(entry)
 
         for baseid, entry_list in monster_entries_by_base_id.items():
             name = self.module.project.get_string_provider().get_value(StringType.POKEMON_NAMES, baseid)
@@ -857,7 +857,10 @@ Each drop type x has a chance of (x rate)/(sum of all the rates) to be selected.
                 gui_entry_cat.set_sensitive(False)
 
     def _init_entid(self):
-        self.builder.get_object(f'label_base_id').set_text(f'#{self.entry.md_index_base:03}')
+        if not self.module.project.is_patch_applied("ExpandPokeList"):
+            self.builder.get_object(f'label_base_id').set_text(f'#{self.entry.md_index_base:03}')
+        else:
+            self.builder.get_object(f'label_base_id').set_text(f'See Entity ID')
         name = self._string_provider.get_value(StringType.POKEMON_NAMES, self.entry.md_index_base)
         self.builder.get_object('label_id_name').set_text(f'${self.entry.md_index:04d}: {name}')
 
@@ -889,11 +892,15 @@ Each drop type x has a chance of (x rate)/(sum of all the rates) to be selected.
             gui_entry_cat: Gtk.Entry = self.builder.get_object(f'entry_lang{gui_id}_cat')
             if lang_id < len(langs):
                 # We have this language
+                if not self.module.project.is_patch_applied('ExpandPokeList'):
+                    idx = self.entry.md_index_base
+                else:
+                    idx = self.entry.md_index
                 gui_entry.set_text(self._string_provider.get_value(StringType.POKEMON_NAMES,
-                                                                   self.entry.md_index_base,
+                                                                   idx,
                                                                    langs[lang_id]))
                 gui_entry_cat.set_text(self._string_provider.get_value(StringType.POKEMON_CATEGORIES,
-                                                                       self.entry.md_index_base,
+                                                                       idx,
                                                                        langs[lang_id]))
 
         # Stats
@@ -1013,15 +1020,23 @@ Each drop type x has a chance of (x rate)/(sum of all the rates) to be selected.
 
     def _update_lang_from_entry(self, w: Gtk.Entry, lang_index):
         lang = self._string_provider.get_languages()[lang_index]
+        if not self.module.project.is_patch_applied('ExpandPokeList'):
+            idx = self.entry.md_index_base
+        else:
+            idx = self.entry.md_index
         self._string_provider.get_model(lang).strings[
-            self._string_provider.get_index(StringType.POKEMON_NAMES, self.entry.md_index_base)
+            self._string_provider.get_index(StringType.POKEMON_NAMES, idx)
         ] = w.get_text()
         self.module.update_monster_sort_lists(lang)
 
     def _update_lang_cat_from_entry(self, w: Gtk.Entry, lang_index):
+        if not self.module.project.is_patch_applied('ExpandPokeList'):
+            idx = self.entry.md_index_base
+        else:
+            idx = self.entry.md_index
         lang = self._string_provider.get_languages()[lang_index]
         self._string_provider.get_model(lang).strings[
-            self._string_provider.get_index(StringType.POKEMON_CATEGORIES, self.entry.md_index_base)
+            self._string_provider.get_index(StringType.POKEMON_CATEGORIES, idx)
         ] = w.get_text()
 
     def _init_sub_pages(self):
@@ -1059,8 +1074,14 @@ Each drop type x has a chance of (x rate)/(sum of all the rates) to be selected.
                 if entry_id > MdProperties.NUM_ENTITIES:
                     raise ValueError()
                 entry = self.module.monster_md[entry_id]
-                name = self._string_provider.get_value(StringType.POKEMON_NAMES, entry.md_index_base)
-                label.set_text(f'#{entry.md_index_base:03d}: {name}')
+                if not self.module.project.is_patch_applied('ExpandPokeList'):
+                    idx = entry.md_index_base
+                    p = '#'
+                else:
+                    idx = entry.md_index
+                    p = '$'
+                name = self._string_provider.get_value(StringType.POKEMON_NAMES, idx)
+                label.set_text(f'{p}{idx:04d}: {name}')
             else:
                 label.set_text(f'')
         except BaseException:
@@ -1074,8 +1095,14 @@ Each drop type x has a chance of (x rate)/(sum of all the rates) to be selected.
             if entry_id > MdProperties.NUM_ENTITIES:
                 raise ValueError()
             entry = self.module.monster_md[entry_id]
-            name = self._string_provider.get_value(StringType.POKEMON_NAMES, entry.md_index_base)
-            label.set_text(f'#{entry.md_index_base:03d}: {name}')
+            if not self.module.project.is_patch_applied('ExpandPokeList'):
+                idx = entry.md_index_base
+                p = '#'
+            else:
+                idx = entry.md_index
+                p = '$'
+            name = self._string_provider.get_value(StringType.POKEMON_NAMES, idx)
+            label.set_text(f'{p}{idx:04d}: {name}')
         except BaseException:
             label.set_text(_('??? Enter a valid Base ID (#)'))
 
@@ -1085,7 +1112,11 @@ Each drop type x has a chance of (x rate)/(sum of all the rates) to be selected.
         try:
             entry_id = int(entry.get_text())
             entry = self.module.monster_md[entry_id]
-            name = self._string_provider.get_value(StringType.POKEMON_NAMES, entry.md_index_base)
+            if not self.module.project.is_patch_applied('ExpandPokeList'):
+                idx = entry.md_index_base
+            else:
+                idx = entry.md_index
+            name = self._string_provider.get_value(StringType.POKEMON_NAMES, idx)
             label.set_text(f'${entry.md_index:04d}: {name} ({entry.gender.name[0]})')
         except BaseException:
             label.set_text(_('??? Enter a valid Entry ID ($)'))
@@ -1140,7 +1171,7 @@ Each drop type x has a chance of (x rate)/(sum of all the rates) to be selected.
         table matches the currently selected sprite of the Pokémon. If not, change
         the value and save it.
         """
-        md_gender1, md_gender2 = self.module.get_entry_both(self.entry.md_index_base)
+        md_gender1, md_gender2 = self.module.get_entry_both(getattr(self.entry, self.module.effective_base_attr))
         try:
             # If ExpandPokeList is applied, unk17 and unk18 are the values used instead
             # (Note: they aren't used in the current state)
@@ -1162,7 +1193,7 @@ Each drop type x has a chance of (x rate)/(sum of all the rates) to be selected.
                     self.entry.unk17 = max_tile_slots_needed
                     self._set_entry('entry_unk17', self.entry.unk17)
                 else:
-                    sprite_size_table[md_gender1.md_index_base].sprite_tile_slots = max_tile_slots_needed
+                    sprite_size_table[getattr(md_gender1, self.module.effective_base_attr)].sprite_tile_slots = max_tile_slots_needed
                     self.module.set_pokemon_sprite_data_table(sprite_size_table)
 
                 if show_warning:
@@ -1182,7 +1213,7 @@ Each drop type x has a chance of (x rate)/(sum of all the rates) to be selected.
                     self.entry.unk18 = max_file_size_needed
                     self._set_entry('entry_unk18', self.entry.unk18)
                 else:
-                    sprite_size_table[md_gender1.md_index_base].unk1 = max_file_size_needed
+                    sprite_size_table[getattr(md_gender1, self.module.effective_base_attr)].unk1 = max_file_size_needed
                     self.module.set_pokemon_sprite_data_table(sprite_size_table)
 
                 if show_warning:
@@ -1207,12 +1238,29 @@ Each drop type x has a chance of (x rate)/(sum of all the rates) to be selected.
         for idx, entry in enumerate(monster_md.entries):
             if idx == 0:
                 continue
-            name = self.module.project.get_string_provider().get_value(StringType.POKEMON_NAMES, entry.md_index_base)
+            if not self.module.project.is_patch_applied('ExpandPokeList'):
+                sidx = self.entry.md_index_base
+            else:
+                sidx = self.entry.md_index
+            name = self.module.project.get_string_provider().get_value(StringType.POKEMON_NAMES, sidx)
             self._ent_names[idx] = f'{name} ({entry.gender.print_name}) (#{idx:04})'
             monster_store.append([self._ent_names[idx]])
     
     def on_cr_entity_editing_started(self, renderer, editable, path):
         editable.set_completion(self.builder.get_object('completion_entities'))
+
+    def on_btn_help_entid_clicked(self, w, *args):
+        md = SkyTempleMessageDialog(
+            MainController.window(),
+            Gtk.DialogFlags.DESTROY_WITH_PARENT, Gtk.MessageType.INFO,
+            Gtk.ButtonsType.OK,
+            _("If the 'ExpandPokeList' patch is not applied, this is unused. Note however that it is used to build groups when applying the patches.\n"
+              "After the patch is applied, this value defines the Base ID and therefore how Pokémon are grouped.\n"
+              "Reload the project after making changes to this value, to reflect them in the tree on the left."),
+            title=_("Entity ID")
+        )
+        md.run()
+        md.destroy()
 
     def on_btn_help_evo_egg_clicked(self, w, *args):
         md = SkyTempleMessageDialog(

--- a/skytemple/module/monster/controller/monster.py
+++ b/skytemple/module/monster/controller/monster.py
@@ -99,6 +99,14 @@ class MonsterController(AbstractController):
         self._update_base_form_label()
         self._update_param_label()
         self._update_chance_label()
+        
+        if self.module.project.is_patch_applied("ExpandPokeList"):
+            self.builder.get_object('lbl_unk_1_0').set_text(_("Spinda Egg"))
+            self.builder.get_object('lbl_unk_1_1').set_text(_("Spinda Recruit"))
+            self.builder.get_object('lbl_unk_1_2').set_text(_("Don't appear in Missions"))
+            self.builder.get_object('lbl_unk_1_3').set_text(_("Don't appear in Missions during story"))
+            self.builder.get_object('lbl_unk_17').set_text(_("Sprite Size"))
+            self.builder.get_object('lbl_unk_18').set_text(_("Sprite File Size"))
 
         self._ent_names = {}
         

--- a/skytemple/module/portrait/portrait_provider.py
+++ b/skytemple/module/portrait/portrait_provider.py
@@ -22,7 +22,7 @@ from gi.repository import Gdk, GdkPixbuf, Gtk
 
 from skytemple.core.img_utils import pil_to_cairo_surface
 from skytemple_files.common.task_runner import AsyncTaskRunner
-from skytemple_files.data.md.model import NUM_ENTITIES
+from skytemple_files.data.md.model import MdProperties
 from skytemple_files.graphics.kao.model import Kao, KAO_IMG_METAPIXELS_DIM, KAO_IMG_IMG_DIM
 
 IMG_DIM = KAO_IMG_METAPIXELS_DIM * KAO_IMG_IMG_DIM
@@ -98,7 +98,7 @@ class PortraitProvider:
             if kao is None or kao.empty is True:
                 if allow_fallback:
                     is_fallback = True
-                    kao = self._kao.get(entry_id % NUM_ENTITIES, sub_id)
+                    kao = self._kao.get(entry_id % MdProperties.NUM_ENTITIES, sub_id)
                     if kao is None:
                         raise RuntimeError()
                 else:


### PR DESCRIPTION
See SkyTemple/skytemple-files#108

Adds UI support for the patch

Also fixes Sprite file size values when changing the sprite index, and N2M/M2N lists (that contain keys to sort recruited Pokémon by species name) when changing a Pokémon's name