### PR TITLE
Initial support for editing ROM metadata (#182)

### DIFF
--- a/skytemple/core/rom_project.py
+++ b/skytemple/core/rom_project.py
@@ -40,6 +40,7 @@ from skytemple_files.common.util import get_files_from_rom_with_extension, get_r
 from skytemple_files.container.sir0.sir0_serializable import Sir0Serializable
 from skytemple_files.patch.patches import Patcher
 from skytemple_files.compression_container.common_at.handler import CommonAtType
+from skytemple_files.hardcoded.icon_banner import IconBanner
 
 logger = logging.getLogger(__name__)
 
@@ -136,6 +137,8 @@ class RomProject:
         # Callback for opening views using iterators from the main view list.
         self._cb_open_view: Callable[[Gtk.TreeIter], None] = cb_open_view
         self._project_fm = ProjectFileManager(filename)
+
+        self._icon_banner: Optional[IconBanner] = None
         
         # Lazy
         self._patcher = None
@@ -153,6 +156,7 @@ class RomProject:
 
         self._sprite_renderer = SpriteProvider(self)
         self._string_provider = StringProvider(self)
+        self._icon_banner = IconBanner(self._rom)
 
     def get_rom_module(self) -> 'RomModule':
         return self._rom_module
@@ -168,6 +172,21 @@ class RomProject:
 
     def get_module(self, name):
         return self._loaded_modules[name]
+
+    def get_icon_banner(self) -> IconBanner:
+        return self._icon_banner
+
+    def get_rom_name(self) -> str:
+        return self._rom.name.decode('ascii')
+
+    def set_rom_name(self, name: str):
+        self._rom.name = name.encode('ascii')
+
+    def get_id_code(self) -> str:
+        return self._rom.idCode.decode('ascii')
+
+    def set_id_code(self, id_code: str):
+        self._rom.idCode = id_code.encode('ascii')
 
     def open_file_in_rom(self, file_path_in_rom: str, file_handler_class: Type[DataHandler[T]],
                          threadsafe=False, **kwargs) -> Union[T, ModelContext[T]]:
@@ -272,6 +291,8 @@ class RomProject:
             for name in self._modified_files:
                 self.prepare_save_model(name)
             self._modified_files = []
+            if self._icon_banner:
+                self._icon_banner.save_to_rom()
             self._forced_modified = False
             logger.debug(f"Saving ROM to {self.filename}")
             self.save_as_is()

--- a/skytemple/data/locale/skytemple.pot
+++ b/skytemple/data/locale/skytemple.pot
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: skytemple\n"
 "Report-Msgid-Bugs-To: https://translate.skytemple.org\n"
-"POT-Creation-Date: 2021-05-16 18:34+0000\n"
+"POT-Creation-Date: 2021-05-26 19:43+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -10724,10 +10724,44 @@ msgstr ""
 msgid " (flip)"
 msgstr ""
 
-#: skytemple/skytemple/module/rom/controller/main.py:39
-msgid ""
-"Select something to edit in the ROM from the tree on the left \n"
-"or start the debugger by clicking the bug icon on the top right."
+#: skytemple/skytemple/module/rom/controller/rom.glade:36
+msgid "Internal name:"
+msgstr ""
+
+#: skytemple/skytemple/module/rom/controller/rom.glade:48
+msgid "ID code: "
+msgstr ""
+
+#: skytemple/skytemple/module/rom/controller/rom.glade:109
+msgid "Rom Settings"
+msgstr ""
+
+#: skytemple/skytemple/module/rom/controller/rom.glade:138
+msgid "Japanese:"
+msgstr ""
+
+#: skytemple/skytemple/module/rom/controller/rom.glade:150
+msgid "English:"
+msgstr ""
+
+#: skytemple/skytemple/module/rom/controller/rom.glade:162
+msgid "French:"
+msgstr ""
+
+#: skytemple/skytemple/module/rom/controller/rom.glade:174
+msgid "German:"
+msgstr ""
+
+#: skytemple/skytemple/module/rom/controller/rom.glade:186
+msgid "Italian:"
+msgstr ""
+
+#: skytemple/skytemple/module/rom/controller/rom.glade:198
+msgid "Spanish:"
+msgstr ""
+
+#: skytemple/skytemple/module/rom/controller/rom.glade:289
+msgid "Title:"
 msgstr ""
 
 #: skytemple/skytemple/module/script/controller/dialog/pos_mark_editor.py:74

--- a/skytemple/data/locale/skytemple.pot
+++ b/skytemple/data/locale/skytemple.pot
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: skytemple\n"
 "Report-Msgid-Bugs-To: https://translate.skytemple.org\n"
-"POT-Creation-Date: 2021-05-26 19:43+0000\n"
+"POT-Creation-Date: 2021-06-03 12:18+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -10732,35 +10732,35 @@ msgstr ""
 msgid "ID code: "
 msgstr ""
 
-#: skytemple/skytemple/module/rom/controller/rom.glade:109
+#: skytemple/skytemple/module/rom/controller/rom.glade:110
 msgid "Rom Settings"
 msgstr ""
 
-#: skytemple/skytemple/module/rom/controller/rom.glade:138
+#: skytemple/skytemple/module/rom/controller/rom.glade:139
 msgid "Japanese:"
 msgstr ""
 
-#: skytemple/skytemple/module/rom/controller/rom.glade:150
+#: skytemple/skytemple/module/rom/controller/rom.glade:151
 msgid "English:"
 msgstr ""
 
-#: skytemple/skytemple/module/rom/controller/rom.glade:162
+#: skytemple/skytemple/module/rom/controller/rom.glade:163
 msgid "French:"
 msgstr ""
 
-#: skytemple/skytemple/module/rom/controller/rom.glade:174
+#: skytemple/skytemple/module/rom/controller/rom.glade:175
 msgid "German:"
 msgstr ""
 
-#: skytemple/skytemple/module/rom/controller/rom.glade:186
+#: skytemple/skytemple/module/rom/controller/rom.glade:187
 msgid "Italian:"
 msgstr ""
 
-#: skytemple/skytemple/module/rom/controller/rom.glade:198
+#: skytemple/skytemple/module/rom/controller/rom.glade:199
 msgid "Spanish:"
 msgstr ""
 
-#: skytemple/skytemple/module/rom/controller/rom.glade:289
+#: skytemple/skytemple/module/rom/controller/rom.glade:290
 msgid "Title:"
 msgstr ""
 

--- a/skytemple/data/locale/skytemple.pot
+++ b/skytemple/data/locale/skytemple.pot
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: skytemple\n"
 "Report-Msgid-Bugs-To: https://translate.skytemple.org\n"
-"POT-Creation-Date: 2021-06-03 12:18+0000\n"
+"POT-Creation-Date: 2021-06-03 12:52+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -10760,7 +10760,7 @@ msgstr ""
 msgid "Spanish:"
 msgstr ""
 
-#: skytemple/skytemple/module/rom/controller/rom.glade:290
+#: skytemple/skytemple/module/rom/controller/rom.glade:212
 msgid "Title:"
 msgstr ""
 

--- a/skytemple/data/locale/skytemple.pot
+++ b/skytemple/data/locale/skytemple.pot
@@ -7,7 +7,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: skytemple\n"
 "Report-Msgid-Bugs-To: https://translate.skytemple.org\n"
-"POT-Creation-Date: 2021-06-03 12:52+0000\n"
+"POT-Creation-Date: 2021-06-04 14:36+0000\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -6147,6 +6147,7 @@ msgstr ""
 #: skytemple/skytemple/module/misc_graphics/controller/zmappat.glade:42
 #: skytemple/skytemple/module/monster/controller/monster.glade:850
 #: skytemple/skytemple/module/portrait/controller/portrait.glade:219
+#: skytemple/skytemple/module/rom/controller/rom.glade:153
 #: skytemple/skytemple/module/sprite/controller/monster_sprite.glade:457
 #: skytemple/skytemple/module/sprite/controller/object.glade:107
 #: skytemple/skytemple/module/strings/controller/strings.glade:153
@@ -6166,6 +6167,7 @@ msgstr ""
 #: skytemple/skytemple/module/misc_graphics/controller/zmappat.glade:79
 #: skytemple/skytemple/module/monster/controller/monster.glade:895
 #: skytemple/skytemple/module/portrait/controller/portrait.glade:258
+#: skytemple/skytemple/module/rom/controller/rom.glade:107
 #: skytemple/skytemple/module/sprite/controller/monster_sprite.glade:502
 #: skytemple/skytemple/module/sprite/controller/object.glade:152
 #: skytemple/skytemple/module/strings/controller/strings.glade:198
@@ -10717,6 +10719,7 @@ msgid ""
 msgstr ""
 
 #: skytemple/skytemple/module/portrait/controller/portrait.py:238
+#: skytemple/skytemple/module/rom/controller/main.py:129
 msgid "Could not import."
 msgstr ""
 
@@ -10724,43 +10727,55 @@ msgstr ""
 msgid " (flip)"
 msgstr ""
 
-#: skytemple/skytemple/module/rom/controller/rom.glade:36
-msgid "Internal name:"
+#: skytemple/skytemple/module/rom/controller/main.py:91
+msgid "Export game icon as PNG..."
 msgstr ""
 
-#: skytemple/skytemple/module/rom/controller/rom.glade:48
-msgid "ID code: "
+#: skytemple/skytemple/module/rom/controller/main.py:110
+msgid "Import game icon from PNG..."
 msgstr ""
 
-#: skytemple/skytemple/module/rom/controller/rom.glade:110
+#: skytemple/skytemple/module/rom/controller/main.py:128
+msgid "Failed importing game icon:\n"
+msgstr ""
+
+#: skytemple/skytemple/module/rom/controller/rom.glade:40
 msgid "Rom Settings"
 msgstr ""
 
-#: skytemple/skytemple/module/rom/controller/rom.glade:139
+#: skytemple/skytemple/module/rom/controller/rom.glade:193
+msgid "Internal name:"
+msgstr ""
+
+#: skytemple/skytemple/module/rom/controller/rom.glade:220
+msgid "ID code: "
+msgstr ""
+
+#: skytemple/skytemple/module/rom/controller/rom.glade:275
 msgid "Japanese:"
 msgstr ""
 
-#: skytemple/skytemple/module/rom/controller/rom.glade:151
+#: skytemple/skytemple/module/rom/controller/rom.glade:287
 msgid "English:"
 msgstr ""
 
-#: skytemple/skytemple/module/rom/controller/rom.glade:163
+#: skytemple/skytemple/module/rom/controller/rom.glade:299
 msgid "French:"
 msgstr ""
 
-#: skytemple/skytemple/module/rom/controller/rom.glade:175
+#: skytemple/skytemple/module/rom/controller/rom.glade:311
 msgid "German:"
 msgstr ""
 
-#: skytemple/skytemple/module/rom/controller/rom.glade:187
+#: skytemple/skytemple/module/rom/controller/rom.glade:323
 msgid "Italian:"
 msgstr ""
 
-#: skytemple/skytemple/module/rom/controller/rom.glade:199
+#: skytemple/skytemple/module/rom/controller/rom.glade:335
 msgid "Spanish:"
 msgstr ""
 
-#: skytemple/skytemple/module/rom/controller/rom.glade:212
+#: skytemple/skytemple/module/rom/controller/rom.glade:348
 msgid "Title:"
 msgstr ""
 

--- a/skytemple/module/rom/controller/rom.glade
+++ b/skytemple/module/rom/controller/rom.glade
@@ -69,6 +69,7 @@
                 <child>
                   <object class="GtkEntry" id="id_code">
                     <property name="visible">True</property>
+                    <property name="sensitive">False</property>
                     <property name="can-focus">True</property>
                     <property name="max-length">4</property>
                     <property name="width-chars">6</property>

--- a/skytemple/module/rom/controller/rom.glade
+++ b/skytemple/module/rom/controller/rom.glade
@@ -18,76 +18,6 @@
             <property name="can-focus">False</property>
             <property name="orientation">vertical</property>
             <child>
-              <!-- n-columns=4 n-rows=1 -->
-              <object class="GtkGrid">
-                <property name="visible">True</property>
-                <property name="can-focus">False</property>
-                <property name="margin-start">5</property>
-                <property name="margin-end">5</property>
-                <property name="margin-top">5</property>
-                <property name="margin-bottom">5</property>
-                <property name="row-spacing">5</property>
-                <property name="column-spacing">5</property>
-                <child>
-                  <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="halign">end</property>
-                    <property name="label" translatable="yes">Internal name:</property>
-                  </object>
-                  <packing>
-                    <property name="left-attach">0</property>
-                    <property name="top-attach">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="halign">end</property>
-                    <property name="label" translatable="yes">ID code: </property>
-                  </object>
-                  <packing>
-                    <property name="left-attach">2</property>
-                    <property name="top-attach">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkEntry" id="name">
-                    <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="margin-end">12</property>
-                    <property name="max-length">12</property>
-                    <property name="width-chars">17</property>
-                    <signal name="changed" handler="on_name_changed" swapped="no"/>
-                  </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkEntry" id="id_code">
-                    <property name="visible">True</property>
-                    <property name="sensitive">False</property>
-                    <property name="can-focus">True</property>
-                    <property name="max-length">4</property>
-                    <property name="width-chars">6</property>
-                    <signal name="changed" handler="on_id_code_changed" swapped="no"/>
-                  </object>
-                  <packing>
-                    <property name="left-attach">3</property>
-                    <property name="top-attach">0</property>
-                  </packing>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
               <object class="GtkImage">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
@@ -116,6 +46,212 @@
                 <property name="expand">False</property>
                 <property name="fill">True</property>
                 <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="spacing">5</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
+                    <property name="spacing">5</property>
+                    <child>
+                      <object class="GtkDrawingArea" id="draw_icon">
+                        <property name="width-request">64</property>
+                        <property name="height-request">64</property>
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="margin-end">10</property>
+                        <signal name="draw" handler="on_draw_icon_draw" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="export_icon">
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">True</property>
+                        <property name="valign">center</property>
+                        <signal name="clicked" handler="on_export_icon_clicked" swapped="no"/>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="orientation">vertical</property>
+                            <property name="spacing">5</property>
+                            <child>
+                              <object class="GtkImage">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="icon-name">skytemple-export-symbolic</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label" translatable="yes">Export</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButton" id="import_icon">
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="receives-default">True</property>
+                        <property name="valign">center</property>
+                        <signal name="clicked" handler="on_import_icon_clicked" swapped="no"/>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="orientation">vertical</property>
+                            <property name="spacing">5</property>
+                            <child>
+                              <object class="GtkImage">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="icon-name">skytemple-import-symbolic</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="label" translatable="yes">Import</property>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">2</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <!-- n-columns=2 n-rows=2 -->
+                  <object class="GtkGrid">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="margin-start">5</property>
+                    <property name="margin-end">5</property>
+                    <property name="margin-top">5</property>
+                    <property name="margin-bottom">5</property>
+                    <property name="row-spacing">5</property>
+                    <property name="column-spacing">5</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">end</property>
+                        <property name="label" translatable="yes">Internal name:</property>
+                      </object>
+                      <packing>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkEntry" id="name">
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="halign">start</property>
+                        <property name="margin-end">12</property>
+                        <property name="max-length">12</property>
+                        <property name="width-chars">17</property>
+                        <signal name="changed" handler="on_name_changed" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="halign">end</property>
+                        <property name="label" translatable="yes">ID code: </property>
+                      </object>
+                      <packing>
+                        <property name="left-attach">0</property>
+                        <property name="top-attach">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkEntry" id="id_code">
+                        <property name="visible">True</property>
+                        <property name="sensitive">False</property>
+                        <property name="can-focus">True</property>
+                        <property name="halign">start</property>
+                        <property name="max-length">4</property>
+                        <property name="width-chars">6</property>
+                        <signal name="changed" handler="on_id_code_changed" swapped="no"/>
+                      </object>
+                      <packing>
+                        <property name="left-attach">1</property>
+                        <property name="top-attach">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="pack-type">end</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
               </packing>
             </child>
             <child>
@@ -225,6 +361,7 @@
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="shadow-type">in</property>
+                    <property name="min-content-height">58</property>
                     <child>
                       <object class="GtkTextView" id="title_japanese">
                         <property name="visible">True</property>

--- a/skytemple/module/rom/controller/rom.glade
+++ b/skytemple/module/rom/controller/rom.glade
@@ -204,84 +204,6 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkTextView" id="title_japanese">
-                    <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="hexpand">True</property>
-                    <property name="wrap-mode">word</property>
-                  </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">1</property>
-                    <property name="width">2</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkTextView" id="title_english">
-                    <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="hexpand">True</property>
-                    <property name="wrap-mode">word</property>
-                  </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">2</property>
-                    <property name="width">2</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkTextView" id="title_french">
-                    <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="hexpand">True</property>
-                    <property name="wrap-mode">word</property>
-                  </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">3</property>
-                    <property name="width">2</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkTextView" id="title_german">
-                    <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="hexpand">True</property>
-                    <property name="wrap-mode">word</property>
-                  </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">4</property>
-                    <property name="width">2</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkTextView" id="title_italian">
-                    <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="hexpand">True</property>
-                    <property name="wrap-mode">word</property>
-                  </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">5</property>
-                    <property name="width">2</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkTextView" id="title_spanish">
-                    <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="hexpand">True</property>
-                    <property name="wrap-mode">word</property>
-                  </object>
-                  <packing>
-                    <property name="left-attach">1</property>
-                    <property name="top-attach">6</property>
-                    <property name="width">2</property>
-                  </packing>
-                </child>
-                <child>
                   <object class="GtkLabel">
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
@@ -295,6 +217,126 @@
                   <packing>
                     <property name="left-attach">0</property>
                     <property name="top-attach">0</property>
+                    <property name="width">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkScrolledWindow">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="shadow-type">in</property>
+                    <child>
+                      <object class="GtkTextView" id="title_japanese">
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="hexpand">True</property>
+                        <property name="wrap-mode">word</property>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">1</property>
+                    <property name="width">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkScrolledWindow">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="shadow-type">in</property>
+                    <child>
+                      <object class="GtkTextView" id="title_spanish">
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="hexpand">True</property>
+                        <property name="wrap-mode">word</property>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">6</property>
+                    <property name="width">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkScrolledWindow">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="shadow-type">in</property>
+                    <child>
+                      <object class="GtkTextView" id="title_italian">
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="hexpand">True</property>
+                        <property name="wrap-mode">word</property>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">5</property>
+                    <property name="width">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkScrolledWindow">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="shadow-type">in</property>
+                    <child>
+                      <object class="GtkTextView" id="title_german">
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="hexpand">True</property>
+                        <property name="wrap-mode">word</property>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">4</property>
+                    <property name="width">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkScrolledWindow">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="shadow-type">in</property>
+                    <child>
+                      <object class="GtkTextView" id="title_french">
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="hexpand">True</property>
+                        <property name="wrap-mode">word</property>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">3</property>
+                    <property name="width">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkScrolledWindow">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="shadow-type">in</property>
+                    <child>
+                      <object class="GtkTextView" id="title_english">
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="hexpand">True</property>
+                        <property name="wrap-mode">word</property>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">2</property>
                     <property name="width">2</property>
                   </packing>
                 </child>

--- a/skytemple/module/rom/controller/rom.glade
+++ b/skytemple/module/rom/controller/rom.glade
@@ -1,0 +1,324 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.38.2 -->
+<interface>
+  <requires lib="gtk+" version="3.22"/>
+  <object class="GtkBox" id="box_list">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="orientation">vertical</property>
+    <child>
+      <object class="GtkAlignment">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="xscale">0.8000000119209289</property>
+        <property name="yscale">0.8000000119209289</property>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="orientation">vertical</property>
+            <child>
+              <!-- n-columns=4 n-rows=1 -->
+              <object class="GtkGrid">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="margin-start">5</property>
+                <property name="margin-end">5</property>
+                <property name="margin-top">5</property>
+                <property name="margin-bottom">5</property>
+                <property name="row-spacing">5</property>
+                <property name="column-spacing">5</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="halign">end</property>
+                    <property name="label" translatable="yes">Internal name:</property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="halign">end</property>
+                    <property name="label" translatable="yes">ID code: </property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">2</property>
+                    <property name="top-attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkEntry" id="name">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="margin-end">12</property>
+                    <property name="max-length">12</property>
+                    <property name="width-chars">17</property>
+                    <signal name="changed" handler="on_name_changed" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkEntry" id="id_code">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="max-length">4</property>
+                    <property name="width-chars">6</property>
+                    <signal name="changed" handler="on_id_code_changed" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="left-attach">3</property>
+                    <property name="top-attach">0</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkImage">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="pixel-size">124</property>
+                <property name="icon-name">skytemple-illust-rom</property>
+                <property name="icon_size">3</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="file_name">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="margin-top">20</property>
+                <property name="margin-bottom">20</property>
+                <property name="label" translatable="yes">Rom Settings</property>
+                <style>
+                  <class name="skytemple-view-main-label"/>
+                </style>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <!-- n-columns=3 n-rows=7 -->
+              <object class="GtkGrid">
+                <property name="height-request">300</property>
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="margin-start">5</property>
+                <property name="margin-end">5</property>
+                <property name="margin-top">5</property>
+                <property name="margin-bottom">5</property>
+                <property name="row-spacing">5</property>
+                <property name="column-spacing">8</property>
+                <property name="row-homogeneous">True</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="halign">end</property>
+                    <property name="label" translatable="yes">Japanese:</property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="halign">end</property>
+                    <property name="label" translatable="yes">English:</property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="halign">end</property>
+                    <property name="label" translatable="yes">French:</property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">3</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="halign">end</property>
+                    <property name="label" translatable="yes">German:</property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">4</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="halign">end</property>
+                    <property name="label" translatable="yes">Italian:</property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">5</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="halign">end</property>
+                    <property name="label" translatable="yes">Spanish:</property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">6</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkTextView" id="title_japanese">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="hexpand">True</property>
+                    <property name="wrap-mode">word</property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">1</property>
+                    <property name="width">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkTextView" id="title_english">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="hexpand">True</property>
+                    <property name="wrap-mode">word</property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">2</property>
+                    <property name="width">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkTextView" id="title_french">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="hexpand">True</property>
+                    <property name="wrap-mode">word</property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">3</property>
+                    <property name="width">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkTextView" id="title_german">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="hexpand">True</property>
+                    <property name="wrap-mode">word</property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">4</property>
+                    <property name="width">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkTextView" id="title_italian">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="hexpand">True</property>
+                    <property name="wrap-mode">word</property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">5</property>
+                    <property name="width">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkTextView" id="title_spanish">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="hexpand">True</property>
+                    <property name="wrap-mode">word</property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">6</property>
+                    <property name="width">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="halign">start</property>
+                    <property name="valign">end</property>
+                    <property name="label" translatable="yes">Title:</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                    </attributes>
+                  </object>
+                  <packing>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">0</property>
+                    <property name="width">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <placeholder/>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">3</property>
+              </packing>
+            </child>
+          </object>
+        </child>
+      </object>
+      <packing>
+        <property name="expand">True</property>
+        <property name="fill">True</property>
+        <property name="position">1</property>
+      </packing>
+    </child>
+    <style>
+      <class name="back_illust"/>
+      <class name="bboard"/>
+    </style>
+  </object>
+</interface>

--- a/skytemple/module/rom/module.py
+++ b/skytemple/module/rom/module.py
@@ -25,7 +25,7 @@ from skytemple.core.rom_project import RomProject
 from skytemple.core.ui_utils import generate_item_store_row_label
 from skytemple.module.rom.controller.main import MainController
 from skytemple_files.common.ppmdu_config.data import Pmd2Data
-
+from skytemple.core.ui_utils import recursive_up_item_store_mark_as_modified
 
 class RomModule(AbstractModule):
     @classmethod
@@ -71,3 +71,8 @@ class RomModule(AbstractModule):
 
     def get_static_data(self) -> Pmd2Data:
         return self._static_data
+
+    def mark_as_modified(self):
+        self.project.force_mark_as_modified()
+        row = self._item_store[self._root_node]
+        recursive_up_item_store_mark_as_modified(row)


### PR DESCRIPTION
Allows editing the internal ROM name, ID and localized titles. Also see https://github.com/SkyTemple/skytemple-files/pull/119

~~The layout is broken because adding a line to one language resizes all of them, idk why~~ fixed