### PR TITLE
Guest pokémon UI

### DIFF
--- a/skytemple/module/lists/controller/guest_pokemon.glade
+++ b/skytemple/module/lists/controller/guest_pokemon.glade
@@ -20,6 +20,38 @@
   -->
 <interface>
   <requires lib="gtk+" version="3.22"/>
+  <object class="GtkEntryCompletion" id="completion_monsters">
+    <property name="model">store_completion_monsters</property>
+    <property name="text-column">0</property>
+    <child>
+      <object class="GtkCellRendererText"/>
+      <attributes>
+        <attribute name="text">0</attribute>
+      </attributes>
+    </child>
+  </object>
+  <object class="GtkListStore" id="store_completion_monsters">
+    <columns>
+      <!-- column-name label -->
+      <column type="gchararray"/>
+    </columns>
+  </object>
+  <object class="GtkListStore" id="store_completion_moves">
+    <columns>
+      <!-- column-name label -->
+      <column type="gchararray"/>
+    </columns>
+  </object>
+  <object class="GtkEntryCompletion" id="completion_moves">
+    <property name="model">store_completion_moves</property>
+    <property name="text-column">0</property>
+    <child>
+      <object class="GtkCellRendererText"/>
+      <attributes>
+        <attribute name="text">0</attribute>
+      </attributes>
+    </child>
+  </object>
   <object class="GtkListStore" id="store_tree_extra_dungeon_data">
     <columns>
       <!-- column-name id -->
@@ -178,7 +210,7 @@ If you already have applied it, apply it again to be sure to use the last versio
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
                     <property name="margin-top">20</property>
-                    <property name="label" translatable="yes">Dungeon guest pokémon</property>
+                    <property name="label" translatable="yes">Dungeon Guest Pokémon</property>
                     <style>
                       <class name="skytemple-view-main-label"/>
                     </style>
@@ -194,7 +226,8 @@ If you already have applied it, apply it again to be sure to use the last versio
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
                     <property name="margin-top">5</property>
-                    <property name="label" translatable="yes">From this menu you can change which dungeons add additional guest pokémon to your party when they are uncleared. You can also set some additional restrictions and edit guest pokémon data.</property>
+                    <property name="label" translatable="yes">From this menu you can change which dungeons add additional guest pokémon to your party when they are &lt;b&gt;uncleared&lt;/b&gt;. You can also set some additional restrictions and edit guest pokémon data.</property>
+                    <property name="use-markup">True</property>
                     <property name="justify">center</property>
                     <property name="wrap">True</property>
                   </object>
@@ -250,6 +283,7 @@ If you already have applied it, apply it again to be sure to use the last versio
                                 <property name="height-request">200</property>
                                 <property name="visible">True</property>
                                 <property name="can-focus">True</property>
+                                <property name="halign">start</property>
                                 <property name="hscrollbar-policy">never</property>
                                 <property name="shadow-type">in</property>
                                 <child>
@@ -257,8 +291,6 @@ If you already have applied it, apply it again to be sure to use the last versio
                                     <property name="visible">True</property>
                                     <property name="can-focus">True</property>
                                     <property name="margin-top">5</property>
-                                    <property name="hexpand">True</property>
-                                    <property name="vexpand">True</property>
                                     <property name="model">store_tree_extra_dungeon_data</property>
                                     <property name="search-column">0</property>
                                     <child internal-child="selection">
@@ -280,6 +312,7 @@ If you already have applied it, apply it again to be sure to use the last versio
                                         <property name="title" translatable="yes">Guest pokémon 1</property>
                                         <child>
                                           <object class="GtkCellRendererText" id="cr_extra_dungeon_data_guest_pokemon_1">
+                                            <property name="editable">True</property>
                                             <signal name="edited" handler="on_extra_dungeon_data_guest_pokemon_1_edited" swapped="no"/>
                                           </object>
                                           <attributes>
@@ -292,7 +325,10 @@ If you already have applied it, apply it again to be sure to use the last versio
                                       <object class="GtkTreeViewColumn">
                                         <property name="title" translatable="yes">Guest pokémon 2</property>
                                         <child>
-                                          <object class="GtkCellRendererText" id="cr_extra_dungeon_data_guest_pokemon_2"/>
+                                          <object class="GtkCellRendererText" id="cr_extra_dungeon_data_guest_pokemon_2">
+                                            <property name="editable">True</property>
+                                            <signal name="edited" handler="on_extra_dungeon_data_guest_pokemon_2_edited" swapped="no"/>
+                                          </object>
                                           <attributes>
                                             <attribute name="text">2</attribute>
                                           </attributes>
@@ -303,9 +339,10 @@ If you already have applied it, apply it again to be sure to use the last versio
                                       <object class="GtkTreeViewColumn">
                                         <property name="title" translatable="yes">HLR (uncleared)</property>
                                         <child>
-                                          <object class="GtkCellRendererToggle" id="cr_extra_dungeon_data_hlr_uncleared"/>
+                                          <object class="GtkCellRendererToggle" id="cr_extra_dungeon_data_hlr_uncleared">
+                                            <signal name="toggled" handler="on_extra_dungeon_data_hlr_uncleared_toggled" swapped="no"/>
+                                          </object>
                                           <attributes>
-                                            <attribute name="activatable">3</attribute>
                                             <attribute name="active">3</attribute>
                                           </attributes>
                                         </child>
@@ -315,9 +352,10 @@ If you already have applied it, apply it again to be sure to use the last versio
                                       <object class="GtkTreeViewColumn">
                                         <property name="title" translatable="yes">Disable recruiting</property>
                                         <child>
-                                          <object class="GtkCellRendererToggle" id="cr_extra_dungeon_data_disable_recruiting"/>
+                                          <object class="GtkCellRendererToggle" id="cr_extra_dungeon_data_disable_recruiting">
+                                            <signal name="toggled" handler="on_extra_dungeon_data_disable_recruiting_toggled" swapped="no"/>
+                                          </object>
                                           <attributes>
-                                            <attribute name="activatable">4</attribute>
                                             <attribute name="active">4</attribute>
                                           </attributes>
                                         </child>
@@ -327,9 +365,10 @@ If you already have applied it, apply it again to be sure to use the last versio
                                       <object class="GtkTreeViewColumn">
                                         <property name="title" translatable="yes">SIDE01 check</property>
                                         <child>
-                                          <object class="GtkCellRendererToggle" id="cr_extra_dungeon_data_side01_check"/>
+                                          <object class="GtkCellRendererToggle" id="cr_extra_dungeon_data_side01_check">
+                                            <signal name="toggled" handler="on_extra_dungeon_data_side01_check_toggled" swapped="no"/>
+                                          </object>
                                           <attributes>
-                                            <attribute name="activatable">5</attribute>
                                             <attribute name="active">5</attribute>
                                           </attributes>
                                         </child>
@@ -339,9 +378,10 @@ If you already have applied it, apply it again to be sure to use the last versio
                                       <object class="GtkTreeViewColumn">
                                         <property name="title" translatable="yes">HLR (cleared)</property>
                                         <child>
-                                          <object class="GtkCellRendererToggle" id="cr_extra_dungeon_data_hlr_cleared"/>
+                                          <object class="GtkCellRendererToggle" id="cr_extra_dungeon_data_hlr_cleared">
+                                            <signal name="toggled" handler="on_extra_dungeon_data_hlr_cleared_toggled" swapped="no"/>
+                                          </object>
                                           <attributes>
-                                            <attribute name="activatable">6</attribute>
                                             <attribute name="active">6</attribute>
                                           </attributes>
                                         </child>
@@ -421,6 +461,7 @@ If you already have applied it, apply it again to be sure to use the last versio
                                           <object class="GtkCellRendererText" id="cr_guest_pokemon_poke_id">
                                             <property name="editable">True</property>
                                             <signal name="edited" handler="on_guest_pokemon_poke_id_edited" swapped="no"/>
+                                            <signal name="editing-started" handler="on_guest_pokemon_poke_id_editing_started" swapped="no"/>
                                           </object>
                                           <attributes>
                                             <attribute name="text">2</attribute>
@@ -430,11 +471,11 @@ If you already have applied it, apply it again to be sure to use the last versio
                                     </child>
                                     <child>
                                       <object class="GtkTreeViewColumn">
-                                        <property name="title" translatable="yes">Unk 2</property>
+                                        <property name="title" translatable="yes">Joined at</property>
                                         <child>
-                                          <object class="GtkCellRendererText" id="cr_guest_pokemon_unk2">
+                                          <object class="GtkCellRendererText" id="cr_guest_pokemon_joined_at">
                                             <property name="editable">True</property>
-                                            <signal name="edited" handler="on_guest_pokemon_unk2_edited" swapped="no"/>
+                                            <signal name="edited" handler="on_guest_pokemon_joined_at_edited" swapped="no"/>
                                           </object>
                                           <attributes>
                                             <attribute name="text">3</attribute>
@@ -449,6 +490,7 @@ If you already have applied it, apply it again to be sure to use the last versio
                                           <object class="GtkCellRendererText" id="cr_guest_pokemon_move1">
                                             <property name="editable">True</property>
                                             <signal name="edited" handler="on_guest_pokemon_move1_edited" swapped="no"/>
+                                            <signal name="editing-started" handler="on_guest_pokemon_move_editing_started" swapped="no"/>
                                           </object>
                                           <attributes>
                                             <attribute name="text">4</attribute>
@@ -463,6 +505,7 @@ If you already have applied it, apply it again to be sure to use the last versio
                                           <object class="GtkCellRendererText" id="cr_guest_pokemon_move2">
                                             <property name="editable">True</property>
                                             <signal name="edited" handler="on_guest_pokemon_move2_edited" swapped="no"/>
+                                            <signal name="editing-started" handler="on_guest_pokemon_move_editing_started" swapped="no"/>
                                           </object>
                                           <attributes>
                                             <attribute name="text">5</attribute>
@@ -477,6 +520,7 @@ If you already have applied it, apply it again to be sure to use the last versio
                                           <object class="GtkCellRendererText" id="cr_guest_pokemon_move3">
                                             <property name="editable">True</property>
                                             <signal name="edited" handler="on_guest_pokemon_move3_edited" swapped="no"/>
+                                            <signal name="editing-started" handler="on_guest_pokemon_move_editing_started" swapped="no"/>
                                           </object>
                                           <attributes>
                                             <attribute name="text">6</attribute>
@@ -491,6 +535,7 @@ If you already have applied it, apply it again to be sure to use the last versio
                                           <object class="GtkCellRendererText" id="cr_guest_pokemon_move4">
                                             <property name="editable">True</property>
                                             <signal name="edited" handler="on_guest_pokemon_move4_edited" swapped="no"/>
+                                            <signal name="editing-started" handler="on_guest_pokemon_move_editing_started" swapped="no"/>
                                           </object>
                                           <attributes>
                                             <attribute name="text">7</attribute>
@@ -713,7 +758,7 @@ If you already have applied it, apply it again to be sure to use the last versio
                           <object class="GtkLabel">
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
-                            <property name="label" translatable="yes">Guest pokémon</property>
+                            <property name="label" translatable="yes">Guest Pokémon</property>
                           </object>
                           <packing>
                             <property name="position">1</property>

--- a/skytemple/module/lists/controller/guest_pokemon.glade
+++ b/skytemple/module/lists/controller/guest_pokemon.glade
@@ -1,0 +1,758 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.38.2 -->
+<!--
+  ~ Copyright 2020-2021 Parakoopa and the SkyTemple Contributors
+  ~
+  ~ This file is part of SkyTemple.
+  ~
+  ~ SkyTemple is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ SkyTemple is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+  -->
+<interface>
+  <requires lib="gtk+" version="3.22"/>
+  <object class="GtkListStore" id="store_tree_extra_dungeon_data">
+    <columns>
+      <!-- column-name id -->
+      <column type="gchararray"/>
+      <!-- column-name guest_pokemon_1 -->
+      <column type="gchararray"/>
+      <!-- column-name guest_pokemon_2 -->
+      <column type="gchararray"/>
+      <!-- column-name hlr_uncleared -->
+      <column type="gboolean"/>
+      <!-- column-name disable_recruiting -->
+      <column type="gboolean"/>
+      <!-- column-name side01_check -->
+      <column type="gboolean"/>
+      <!-- column-name hlr_cleared -->
+      <column type="gboolean"/>
+    </columns>
+  </object>
+  <object class="GtkListStore" id="store_tree_guest_pokemon_data">
+    <columns>
+      <!-- column-name id -->
+      <column type="gchararray"/>
+      <!-- column-name unk1 -->
+      <column type="gchararray"/>
+      <!-- column-name poke_id -->
+      <column type="gchararray"/>
+      <!-- column-name unk2 -->
+      <column type="gchararray"/>
+      <!-- column-name move1 -->
+      <column type="gchararray"/>
+      <!-- column-name move2 -->
+      <column type="gchararray"/>
+      <!-- column-name move3 -->
+      <column type="gchararray"/>
+      <!-- column-name move4 -->
+      <column type="gchararray"/>
+      <!-- column-name hp -->
+      <column type="gchararray"/>
+      <!-- column-name level -->
+      <column type="gchararray"/>
+      <!-- column-name iq -->
+      <column type="gchararray"/>
+      <!-- column-name attack -->
+      <column type="gchararray"/>
+      <!-- column-name special_attack -->
+      <column type="gchararray"/>
+      <!-- column-name defense -->
+      <column type="gchararray"/>
+      <!-- column-name special_defense -->
+      <column type="gchararray"/>
+      <!-- column-name unk3 -->
+      <column type="gchararray"/>
+      <!-- column-name exp -->
+      <column type="gchararray"/>
+    </columns>
+  </object>
+  <object class="GtkStack" id="list_stack">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <child>
+      <object class="GtkBox" id="box_na">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkAlignment">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="xscale">0.8000000119209289</property>
+            <property name="yscale">0.8000000119209289</property>
+            <child>
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="orientation">vertical</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="margin-top">64</property>
+                    <property name="label" translatable="yes">Guest pokémon</property>
+                    <style>
+                      <class name="skytemple-view-main-label"/>
+                    </style>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="margin-top">5</property>
+                    <property name="label" translatable="yes">Edits which dungeons add guest pokémon to your party, as well as some additional dungeon restrictions.</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="margin-top">40</property>
+                    <property name="label" translatable="yes">&lt;Not available&gt;
+
+To view and edit guest pokémon data, please apply the "EditExtraPokemon" 
+ASM patch from the "ASM Patches" menu.
+If you already have applied it, apply it again to be sure to use the last version. </property>
+                    <property name="justify">center</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+      <packing>
+        <property name="name">page1</property>
+        <property name="title" translatable="yes">page1</property>
+      </packing>
+    </child>
+    <child>
+      <object class="GtkBox" id="box_list">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkAlignment">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="xscale">0.8000000119209289</property>
+            <property name="yscale">0.8000000119209289</property>
+            <child>
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="orientation">vertical</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="margin-top">20</property>
+                    <property name="label" translatable="yes">Dungeon guest pokémon</property>
+                    <style>
+                      <class name="skytemple-view-main-label"/>
+                    </style>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="margin-top">5</property>
+                    <property name="label" translatable="yes">From this menu you can change which dungeons add additional guest pokémon to your party when they are uncleared. You can also set some additional restrictions and edit guest pokémon data.</property>
+                    <property name="justify">center</property>
+                    <property name="wrap">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="orientation">vertical</property>
+                    <child>
+                      <object class="GtkNotebook" id="nb_sl">
+                        <property name="visible">True</property>
+                        <property name="can-focus">True</property>
+                        <property name="margin-top">5</property>
+                        <signal name="switch-page" handler="on_nb_sl_switch_page" swapped="no"/>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="orientation">vertical</property>
+                            <property name="spacing">5</property>
+                            <child>
+                              <object class="GtkButton" id="help_dungeon_guest_pokemon">
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="receives-default">True</property>
+                                <property name="halign">start</property>
+                                <property name="valign">center</property>
+                                <property name="margin-start">5</property>
+                                <property name="margin-top">5</property>
+                                <signal name="clicked" handler="on_btn_help_extra_dungeon_data_clicked" swapped="no"/>
+                                <child>
+                                  <object class="GtkImage">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="icon-name">skytemple-help-about-symbolic</property>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkScrolledWindow">
+                                <property name="height-request">200</property>
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="hscrollbar-policy">never</property>
+                                <property name="shadow-type">in</property>
+                                <child>
+                                  <object class="GtkTreeView" id="tree_extra_dungeon_data">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="margin-top">5</property>
+                                    <property name="hexpand">True</property>
+                                    <property name="vexpand">True</property>
+                                    <property name="model">store_tree_extra_dungeon_data</property>
+                                    <property name="search-column">0</property>
+                                    <child internal-child="selection">
+                                      <object class="GtkTreeSelection"/>
+                                    </child>
+                                    <child>
+                                      <object class="GtkTreeViewColumn">
+                                        <property name="title" translatable="yes">ID</property>
+                                        <child>
+                                          <object class="GtkCellRendererText" id="cr_extra_dungeon_data_id"/>
+                                          <attributes>
+                                            <attribute name="text">0</attribute>
+                                          </attributes>
+                                        </child>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkTreeViewColumn">
+                                        <property name="title" translatable="yes">Guest pokémon 1</property>
+                                        <child>
+                                          <object class="GtkCellRendererText" id="cr_extra_dungeon_data_guest_pokemon_1">
+                                            <signal name="edited" handler="on_extra_dungeon_data_guest_pokemon_1_edited" swapped="no"/>
+                                          </object>
+                                          <attributes>
+                                            <attribute name="text">1</attribute>
+                                          </attributes>
+                                        </child>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkTreeViewColumn">
+                                        <property name="title" translatable="yes">Guest pokémon 2</property>
+                                        <child>
+                                          <object class="GtkCellRendererText" id="cr_extra_dungeon_data_guest_pokemon_2"/>
+                                          <attributes>
+                                            <attribute name="text">2</attribute>
+                                          </attributes>
+                                        </child>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkTreeViewColumn">
+                                        <property name="title" translatable="yes">HLR (uncleared)</property>
+                                        <child>
+                                          <object class="GtkCellRendererToggle" id="cr_extra_dungeon_data_hlr_uncleared"/>
+                                          <attributes>
+                                            <attribute name="activatable">3</attribute>
+                                            <attribute name="active">3</attribute>
+                                          </attributes>
+                                        </child>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkTreeViewColumn">
+                                        <property name="title" translatable="yes">Disable recruiting</property>
+                                        <child>
+                                          <object class="GtkCellRendererToggle" id="cr_extra_dungeon_data_disable_recruiting"/>
+                                          <attributes>
+                                            <attribute name="activatable">4</attribute>
+                                            <attribute name="active">4</attribute>
+                                          </attributes>
+                                        </child>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkTreeViewColumn">
+                                        <property name="title" translatable="yes">SIDE01 check</property>
+                                        <child>
+                                          <object class="GtkCellRendererToggle" id="cr_extra_dungeon_data_side01_check"/>
+                                          <attributes>
+                                            <attribute name="activatable">5</attribute>
+                                            <attribute name="active">5</attribute>
+                                          </attributes>
+                                        </child>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkTreeViewColumn">
+                                        <property name="title" translatable="yes">HLR (cleared)</property>
+                                        <child>
+                                          <object class="GtkCellRendererToggle" id="cr_extra_dungeon_data_hlr_cleared"/>
+                                          <attributes>
+                                            <attribute name="activatable">6</attribute>
+                                            <attribute name="active">6</attribute>
+                                          </attributes>
+                                        </child>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                        </child>
+                        <child type="tab">
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">Dungeons</property>
+                          </object>
+                          <packing>
+                            <property name="tab-fill">False</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="margin-bottom">10</property>
+                            <property name="orientation">vertical</property>
+                            <property name="spacing">10</property>
+                            <child>
+                              <object class="GtkScrolledWindow">
+                                <property name="visible">True</property>
+                                <property name="can-focus">True</property>
+                                <property name="shadow-type">in</property>
+                                <child>
+                                  <object class="GtkTreeView" id="tree_guest_pokemon_data">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="model">store_tree_guest_pokemon_data</property>
+                                    <property name="search-column">0</property>
+                                    <child internal-child="selection">
+                                      <object class="GtkTreeSelection"/>
+                                    </child>
+                                    <child>
+                                      <object class="GtkTreeViewColumn">
+                                        <property name="title" translatable="yes">ID</property>
+                                        <child>
+                                          <object class="GtkCellRendererText" id="cr_guest_pokemon_id"/>
+                                          <attributes>
+                                            <attribute name="text">0</attribute>
+                                          </attributes>
+                                        </child>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkTreeViewColumn">
+                                        <property name="title" translatable="yes">Unk 1</property>
+                                        <child>
+                                          <object class="GtkCellRendererText" id="cr_guest_pokemon_unk1">
+                                            <property name="editable">True</property>
+                                            <signal name="edited" handler="on_guest_pokemon_unk1_edited" swapped="no"/>
+                                          </object>
+                                          <attributes>
+                                            <attribute name="text">1</attribute>
+                                          </attributes>
+                                        </child>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkTreeViewColumn">
+                                        <property name="title" translatable="yes">Pokémon ID</property>
+                                        <child>
+                                          <object class="GtkCellRendererText" id="cr_guest_pokemon_poke_id">
+                                            <property name="editable">True</property>
+                                            <signal name="edited" handler="on_guest_pokemon_poke_id_edited" swapped="no"/>
+                                          </object>
+                                          <attributes>
+                                            <attribute name="text">2</attribute>
+                                          </attributes>
+                                        </child>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkTreeViewColumn">
+                                        <property name="title" translatable="yes">Unk 2</property>
+                                        <child>
+                                          <object class="GtkCellRendererText" id="cr_guest_pokemon_unk2">
+                                            <property name="editable">True</property>
+                                            <signal name="edited" handler="on_guest_pokemon_unk2_edited" swapped="no"/>
+                                          </object>
+                                          <attributes>
+                                            <attribute name="text">3</attribute>
+                                          </attributes>
+                                        </child>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkTreeViewColumn">
+                                        <property name="title" translatable="yes">Move 1</property>
+                                        <child>
+                                          <object class="GtkCellRendererText" id="cr_guest_pokemon_move1">
+                                            <property name="editable">True</property>
+                                            <signal name="edited" handler="on_guest_pokemon_move1_edited" swapped="no"/>
+                                          </object>
+                                          <attributes>
+                                            <attribute name="text">4</attribute>
+                                          </attributes>
+                                        </child>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkTreeViewColumn">
+                                        <property name="title" translatable="yes">Move 2</property>
+                                        <child>
+                                          <object class="GtkCellRendererText" id="cr_guest_pokemon_move2">
+                                            <property name="editable">True</property>
+                                            <signal name="edited" handler="on_guest_pokemon_move2_edited" swapped="no"/>
+                                          </object>
+                                          <attributes>
+                                            <attribute name="text">5</attribute>
+                                          </attributes>
+                                        </child>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkTreeViewColumn">
+                                        <property name="title" translatable="yes">Move 3</property>
+                                        <child>
+                                          <object class="GtkCellRendererText" id="cr_guest_pokemon_move3">
+                                            <property name="editable">True</property>
+                                            <signal name="edited" handler="on_guest_pokemon_move3_edited" swapped="no"/>
+                                          </object>
+                                          <attributes>
+                                            <attribute name="text">6</attribute>
+                                          </attributes>
+                                        </child>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkTreeViewColumn">
+                                        <property name="title" translatable="yes">Move 4</property>
+                                        <child>
+                                          <object class="GtkCellRendererText" id="cr_guest_pokemon_move4">
+                                            <property name="editable">True</property>
+                                            <signal name="edited" handler="on_guest_pokemon_move4_edited" swapped="no"/>
+                                          </object>
+                                          <attributes>
+                                            <attribute name="text">7</attribute>
+                                          </attributes>
+                                        </child>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkTreeViewColumn">
+                                        <property name="title" translatable="yes">HP</property>
+                                        <child>
+                                          <object class="GtkCellRendererText" id="cr_guest_pokemon_hp">
+                                            <property name="editable">True</property>
+                                            <signal name="edited" handler="on_guest_pokemon_hp_edited" swapped="no"/>
+                                          </object>
+                                          <attributes>
+                                            <attribute name="text">8</attribute>
+                                          </attributes>
+                                        </child>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkTreeViewColumn">
+                                        <property name="title" translatable="yes">Level</property>
+                                        <child>
+                                          <object class="GtkCellRendererText" id="cr_guest_pokemon_level">
+                                            <property name="editable">True</property>
+                                            <signal name="edited" handler="on_guest_pokemon_level_edited" swapped="no"/>
+                                          </object>
+                                          <attributes>
+                                            <attribute name="text">9</attribute>
+                                          </attributes>
+                                        </child>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkTreeViewColumn">
+                                        <property name="title" translatable="yes">IQ</property>
+                                        <child>
+                                          <object class="GtkCellRendererText" id="cr_guest_pokemon_iq">
+                                            <property name="editable">True</property>
+                                            <signal name="edited" handler="on_guest_pokemon_iq_edited" swapped="no"/>
+                                          </object>
+                                          <attributes>
+                                            <attribute name="text">10</attribute>
+                                          </attributes>
+                                        </child>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkTreeViewColumn">
+                                        <property name="title" translatable="yes">Atk.</property>
+                                        <child>
+                                          <object class="GtkCellRendererText" id="cr_guest_pokemon_attack">
+                                            <property name="editable">True</property>
+                                            <signal name="edited" handler="on_guest_pokemon_attack_edited" swapped="no"/>
+                                          </object>
+                                          <attributes>
+                                            <attribute name="text">11</attribute>
+                                          </attributes>
+                                        </child>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkTreeViewColumn">
+                                        <property name="title" translatable="yes">Sp. Atk.</property>
+                                        <child>
+                                          <object class="GtkCellRendererText" id="cr_guest_pokemon_special_attack">
+                                            <property name="editable">True</property>
+                                            <signal name="edited" handler="on_guest_pokemon_special_attack_edited" swapped="no"/>
+                                          </object>
+                                          <attributes>
+                                            <attribute name="text">12</attribute>
+                                          </attributes>
+                                        </child>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkTreeViewColumn">
+                                        <property name="title" translatable="yes">Def.</property>
+                                        <child>
+                                          <object class="GtkCellRendererText" id="cr_guest_pokemon_defense">
+                                            <property name="editable">True</property>
+                                            <signal name="edited" handler="on_guest_pokemon_defense_edited" swapped="no"/>
+                                          </object>
+                                          <attributes>
+                                            <attribute name="text">13</attribute>
+                                          </attributes>
+                                        </child>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkTreeViewColumn">
+                                        <property name="title" translatable="yes">Sp. Def.</property>
+                                        <child>
+                                          <object class="GtkCellRendererText" id="cr_guest_pokemon_special_defense">
+                                            <property name="editable">True</property>
+                                            <signal name="edited" handler="on_guest_pokemon_special_defense_edited" swapped="no"/>
+                                          </object>
+                                          <attributes>
+                                            <attribute name="text">14</attribute>
+                                          </attributes>
+                                        </child>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkTreeViewColumn">
+                                        <property name="title" translatable="yes">Unk3</property>
+                                        <child>
+                                          <object class="GtkCellRendererText" id="cr_guest_pokemon_unk3">
+                                            <property name="editable">True</property>
+                                            <signal name="edited" handler="on_guest_pokemon_unk3_edited" swapped="no"/>
+                                          </object>
+                                          <attributes>
+                                            <attribute name="text">15</attribute>
+                                          </attributes>
+                                        </child>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkTreeViewColumn">
+                                        <property name="title" translatable="yes">Exp</property>
+                                        <child>
+                                          <object class="GtkCellRendererText" id="cr_guest_pokemon_exp">
+                                            <property name="editable">True</property>
+                                            <signal name="edited" handler="on_guest_pokemon_exp_edited" swapped="no"/>
+                                          </object>
+                                          <attributes>
+                                            <attribute name="text">16</attribute>
+                                          </attributes>
+                                        </child>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkBox">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="margin-end">10</property>
+                                <property name="spacing">10</property>
+                                <child>
+                                  <object class="GtkButton" id="btn_guest_pokemon_remove">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">True</property>
+                                    <property name="valign">center</property>
+                                    <signal name="clicked" handler="on_guest_pokemon_remove_clicked" swapped="no"/>
+                                    <child>
+                                      <object class="GtkImage">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="icon-name">skytemple-list-remove-symbolic</property>
+                                      </object>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="pack-type">end</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkButton" id="btn_guest_pokemon_add">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">True</property>
+                                    <property name="receives-default">True</property>
+                                    <property name="valign">center</property>
+                                    <signal name="clicked" handler="on_guest_pokemon_add_clicked" swapped="no"/>
+                                    <child>
+                                      <object class="GtkImage">
+                                        <property name="visible">True</property>
+                                        <property name="can-focus">False</property>
+                                        <property name="icon-name">skytemple-list-add-symbolic</property>
+                                      </object>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="pack-type">end</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel" id="label_free_entries_left">
+                                    <property name="visible">True</property>
+                                    <property name="can-focus">False</property>
+                                    <property name="label" translatable="yes">Free entries left: XX</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="pack-type">end</property>
+                                    <property name="position">2</property>
+                                  </packing>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="pack-type">end</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                        <child type="tab">
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="label" translatable="yes">Guest pokémon</property>
+                          </object>
+                          <packing>
+                            <property name="position">1</property>
+                            <property name="tab-fill">False</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">True</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">3</property>
+                  </packing>
+                </child>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <style>
+          <class name="back_illust"/>
+          <class name="music"/>
+        </style>
+      </object>
+      <packing>
+        <property name="name">page0</property>
+        <property name="title" translatable="yes">page0</property>
+        <property name="position">1</property>
+      </packing>
+    </child>
+  </object>
+</interface>

--- a/skytemple/module/lists/controller/guest_pokemon.py
+++ b/skytemple/module/lists/controller/guest_pokemon.py
@@ -1,0 +1,251 @@
+#  Copyright 2020-2021 Parakoopa and the SkyTemple Contributors
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+from typing import TYPE_CHECKING
+
+from gi.repository import Gtk
+from gi.repository.Gtk import Widget
+
+from skytemple.controller.main import MainController
+from skytemple.core.message_dialog import SkyTempleMessageDialog
+from skytemple.core.module_controller import AbstractController
+from skytemple.core.rom_project import BinaryName
+from skytemple_files.common.i18n_util import f, _
+from skytemple_files.hardcoded.guest_pokemon import ExtraDungeonDataList, GuestPokemonList, GuestPokemon, \
+    ExtraDungeonDataEntry
+
+if TYPE_CHECKING:
+    from skytemple.module.lists.module import ListsModule
+
+
+class GuestPokemonController(AbstractController):
+
+    def __init__(self, module: 'ListsModule', item_id: int):
+        self.module = module
+        self.builder = None
+        self.arm9 = module.project.get_binary(BinaryName.ARM9)
+        self.static_data = module.project.get_rom_module().get_static_data()
+
+    def get_view(self) -> Widget:
+        self.builder = self._get_builder(__file__, 'guest_pokemon.glade')
+        stack: Gtk.Stack = self.builder.get_object('list_stack')
+
+        if not self.module.has_edit_extra_pokemon():
+            stack.set_visible_child(self.builder.get_object('box_na'))
+            return stack
+
+        self._fill_extra_dungeon_data()
+        self._fill_guest_pokemon_data()
+        self._update_free_entries_left()
+
+        stack.set_visible_child(self.builder.get_object('box_list'))
+        self.builder.connect_signals(self)
+
+        return stack
+
+    def on_nb_sl_switch_page(self, n: Gtk.Notebook, p, pnum, *args):
+        if pnum == 0:
+            self._fill_extra_dungeon_data()
+        elif pnum == 1:
+            self._fill_guest_pokemon_data()
+
+    def on_btn_help_extra_dungeon_data_clicked(self, *args):
+        self._help(_("- HLR (uncleared): Whether Hidden Land restrictions should be active in the dungeon when you "
+                     "enter it without having cleared it yet.\n"
+                     "Hidden Land restrictions prevent sending pokémon home or changing leaders. In addition, "
+                     "if a team member faints you will get kicked out of the dungeon.\n"
+                     "- Disable recruiting: Only applies when the dungeon is uncleared. If enabled, recruiting will "
+                     "be disabled.\n"
+                     "- SIDE01 check: If enabled, guest pokémon will only be added to the team if the ground variable "
+                     "SIDE01_BOSS2ND is 0.\n"
+                     "- HLR (cleared): Whether Hidden Land restrictions should be enabled in the dungeon when you "
+                     "enter it after it's cleared."))
+    
+    def on_guest_pokemon_add_clicked(self, *args):
+        store: Gtk.ListStore = self.builder.get_object('store_tree_guest_pokemon_data')
+        store.append([
+            str(len(store)), "0", "1", "0", "0", "0", "0", "0", "1", "1", "1", "0", "0", "0", "0", "0", "0"
+        ])
+        self._update_free_entries_left()
+        self._save_guest_pokemon_data()
+
+    def on_guest_pokemon_remove_clicked(self, *args):
+        tree: Gtk.TreeView = self.builder.get_object('tree_guest_pokemon_data')
+        model, treeiter = tree.get_selection().get_selected()
+        # There has to be a better way of getting this value
+        selected_row_index = tree.get_selection().get_selected_rows()[1][0][0]
+        if model is not None and treeiter is not None:
+            model.remove(treeiter)
+        self._update_free_entries_left()
+        self._guest_pokemon_entry_deleted(selected_row_index)
+        self._save_guest_pokemon_data()
+
+    # <editor-fold desc="HANDLERS: Guest pokémon" defaultstate="collapsed">
+    def on_guest_pokemon_unk1_edited(self, widget, path, text):
+        self._update_guest_pokemon_data_value(path, text, 1)
+
+    def on_guest_pokemon_poke_id_edited(self, widget, path, text):
+        self._update_guest_pokemon_data_value(path, text, 2)
+
+    def on_guest_pokemon_unk2_edited(self, widget, path, text):
+        self._update_guest_pokemon_data_value(path, text, 3)
+
+    def on_guest_pokemon_move1_edited(self, widget, path, text):
+        self._update_guest_pokemon_data_value(path, text, 4)
+
+    def on_guest_pokemon_move2_edited(self, widget, path, text):
+        self._update_guest_pokemon_data_value(path, text, 5)
+
+    def on_guest_pokemon_move3_edited(self, widget, path, text):
+        self._update_guest_pokemon_data_value(path, text, 6)
+
+    def on_guest_pokemon_move4_edited(self, widget, path, text):
+        self._update_guest_pokemon_data_value(path, text, 7)
+
+    def on_guest_pokemon_hp_edited(self, widget, path, text):
+        self._update_guest_pokemon_data_value(path, text, 8)
+
+    def on_guest_pokemon_level_edited(self, widget, path, text):
+        self._update_guest_pokemon_data_value(path, text, 9)
+
+    def on_guest_pokemon_iq_edited(self, widget, path, text):
+        self._update_guest_pokemon_data_value(path, text, 10)
+
+    def on_guest_pokemon_attack_edited(self, widget, path, text):
+        self._update_guest_pokemon_data_value(path, text, 11)
+
+    def on_guest_pokemon_special_attack_edited(self, widget, path, text):
+        self._update_guest_pokemon_data_value(path, text, 12)
+
+    def on_guest_pokemon_defense_edited(self, widget, path, text):
+        self._update_guest_pokemon_data_value(path, text, 13)
+
+    def on_guest_pokemon_special_defense_edited(self, widget, path, text):
+        self._update_guest_pokemon_data_value(path, text, 14)
+
+    def on_guest_pokemon_unk3_edited(self, widget, path, text):
+        self._update_guest_pokemon_data_value(path, text, 15)
+
+    def on_guest_pokemon_exp_edited(self, widget, path, text):
+        self._update_guest_pokemon_data_value(path, text, 16)
+    # </editor-fold>
+
+    # <editor-fold desc="HANDLERS: Guest pokémon" defaultstate="collapsed">
+    def on_extra_dungeon_data_guest_pokemon_1_edited(self, widget, path, text):
+        # TOFIX: This never runs for some reason
+        print("TEST")
+        store: Gtk.ListStore = self.builder.get_object('store_tree_extra_dungeon_data')
+        store[path][1] = int(text)
+        self._save_extra_dungeon_data()
+
+    # TODO: Rest of extra dungeon data handlers
+    # </editor-fold>
+
+    def _fill_extra_dungeon_data(self):
+        # Init extra dungeon data store
+        store: Gtk.ListStore = self.builder.get_object('store_tree_extra_dungeon_data')
+        store.clear()
+        for idx, item in enumerate(ExtraDungeonDataList.read(self.arm9, self.static_data)):
+            store.append([
+                str(idx), str(item.guest1_index), str(item.guest2_index), item.hlr_uncleared, item.disable_recruit,
+                item.side01_check, item.hlr_cleared
+            ])
+
+    def _fill_guest_pokemon_data(self):
+        # Init guest pokémon data store
+        store: Gtk.ListStore = self.builder.get_object('store_tree_guest_pokemon_data')
+        store.clear()
+        for i, item in enumerate(GuestPokemonList.read(self.arm9, self.static_data)):
+            store.append([
+                str(i), str(item.unk1), str(item.poke_id), str(item.unk2), str(item.moves[0]), str(item.moves[1]),
+                str(item.moves[2]), str(item.moves[3]), str(item.hp), str(item.level), str(item.iq), str(item.atk),
+                str(item.sp_atk), str(item.def_), str(item.sp_def), str(item.unk3), str(item.exp)
+            ])
+
+    def _save_extra_dungeon_data(self):
+        store: Gtk.ListStore = self.builder.get_object('store_tree_extra_dungeon_data')
+        extra_dungeon_data_list = []
+        for i, row in enumerate(store):
+            extra_dungeon_data_list.append(ExtraDungeonDataEntry(int(row[1]), int(row[2]),
+                                                                 row[3], row[4], row[5], row[6]))
+        self.module.set_extra_dungeon_data(extra_dungeon_data_list)
+        # Update our copy of the binary
+        self.arm9 = self.module.project.get_binary(BinaryName.ARM9)
+
+    def _save_guest_pokemon_data(self):
+        store: Gtk.ListStore = self.builder.get_object('store_tree_guest_pokemon_data')
+        guest_pokemon_list = []
+        for i, row in enumerate(store):
+            guest_pokemon_list.append(GuestPokemon(int(row[1]), int(row[2]), int(row[3]),
+                                                   [int(row[4]), int(row[5]), int(row[6]), int(row[7])],
+                                                   int(row[8]), int(row[9]), int(row[10]), int(row[11]),
+                                                   int(row[12]), int(row[13]), int(row[14]), int(row[15]),
+                                                   int(row[16])))
+        self.module.set_guest_pokemon_data(guest_pokemon_list)
+        # Update our copy of the binary
+        self.arm9 = self.module.project.get_binary(BinaryName.ARM9)
+
+    def _update_free_entries_left(self):
+        store: Gtk.ListStore = self.builder.get_object('store_tree_guest_pokemon_data')
+        entries_left = GuestPokemonList.get_max_entries(self.arm9, self.static_data) - len(store)
+
+        entries_left_text: Gtk.Label = self.builder.get_object('label_free_entries_left')
+        entries_left_text.set_text(f"Free entries left: {entries_left}")
+
+        add_button: Gtk.Button = self.builder.get_object('btn_guest_pokemon_add')
+        if entries_left <= 0:
+            add_button.set_sensitive(False)
+        else:
+            add_button.set_sensitive(True)
+
+    def _guest_pokemon_entry_deleted(self, pos: int):
+        """
+        Updates IDs and references to entries from the extra dungeon data list.
+        Must be called after removing a guest pokémon entry from the list.
+        """
+        store: Gtk.ListStore = self.builder.get_object('store_tree_guest_pokemon_data')
+        for i, row in enumerate(store):
+            row[0] = str(i)
+
+        # Update references
+        store: Gtk.ListStore = self.builder.get_object('store_tree_extra_dungeon_data')
+        for row in enumerate(store):
+            if int(row[1][1]) == pos:
+                row[1][1] = "-1"
+            elif int(row[1][1]) > pos:
+                row[1][1] = str(int(row[1][1]) - 1)
+
+            if int(row[1][2]) == pos:
+                row[1][2] = "-1"
+            elif int(row[1][2]) > pos:
+                row[1][2] = str(int(row[1][2]) - 1)
+        self._save_extra_dungeon_data()
+
+    def _update_guest_pokemon_data_value(self, path, text, value_pos: int):
+        try:
+            v = int(text)
+        except ValueError:
+            return
+        store: Gtk.ListStore = self.builder.get_object('store_tree_guest_pokemon_data')
+        store[path][value_pos] = text
+        self._save_guest_pokemon_data()
+
+    def _help(self, msg):
+        md = SkyTempleMessageDialog(MainController.window(),
+                                    Gtk.DialogFlags.DESTROY_WITH_PARENT, Gtk.MessageType.INFO,
+                                    Gtk.ButtonsType.OK, msg)
+        md.run()
+        md.destroy()

--- a/skytemple/module/lists/module.py
+++ b/skytemple/module/lists/module.py
@@ -33,8 +33,11 @@ from skytemple.module.lists.controller.starters_list import StartersListControll
 from skytemple.module.lists.controller.recruitment_list import RecruitmentListController
 from skytemple.module.lists.controller.world_map import WorldMapController
 from skytemple.module.lists.controller.sp_effects import SPEffectsController
+from skytemple.module.monster.module import WAZA_P_BIN
+from skytemple_files.common.types.file_types import FileType
 from skytemple_files.data.data_cd.handler import DataCDHandler
 from skytemple_files.data.md.model import Md
+from skytemple_files.data.waza_p.model import WazaP
 from skytemple_files.hardcoded.dungeon_music import HardcodedDungeonMusic, DungeonMusicEntry
 from skytemple_files.hardcoded.dungeons import MapMarkerPlacement, HardcodedDungeons
 from skytemple_files.hardcoded.guest_pokemon import ExtraDungeonDataList, ExtraDungeonDataEntry, GuestPokemon, \
@@ -75,6 +78,8 @@ class ListsModule(AbstractModule):
         self._misc_settings_tree_iter = None
         self._guest_pokemon_root_iter = None
 
+        self.waza_p_bin: WazaP = self.project.open_file_in_rom(WAZA_P_BIN, FileType.WAZA_P)
+
     def load_tree_items(self, item_store: TreeStore, root_node):
         root = item_store.append(root_node, [
             'skytemple-view-list-symbolic', GROUND_LISTS, self, MainController, 0, False, '', True
@@ -107,7 +112,7 @@ class ListsModule(AbstractModule):
             'skytemple-view-list-symbolic', _('Misc. Settings'), self, MiscSettingsController, 0, False, '', True
         ])
         self._guest_pokemon_root_iter = item_store.append(root, [
-            'skytemple-e-monster-symbolic', _('Guest pokémon'), self, GuestPokemonController, 0, False, '', True
+            'skytemple-e-monster-symbolic', _('Guest Pokémon'), self, GuestPokemonController, 0, False, '', True
         ])
         generate_item_store_row_label(item_store[root])
         generate_item_store_row_label(item_store[self._actor_tree_iter])
@@ -131,20 +136,20 @@ class ListsModule(AbstractModule):
 
     def get_sp_effects(self):
         return self.project.open_file_in_rom(SP_EFFECTS, DataCDHandler)
-    
+
     def mark_sp_effects_as_modified(self):
         """Mark as modified"""
         self.project.mark_as_modified(SP_EFFECTS)
         # Mark as modified in tree
         row = self._tree_model[self._sp_effects_tree_iter]
         recursive_up_item_store_mark_as_modified(row)
-    
+
     def has_actor_list(self):
         return self.project.file_exists(ACTOR_LIST)
 
     def get_actor_list(self) -> ActorListBin:
         return self.project.open_sir0_file_in_rom(ACTOR_LIST, ActorListBin)
-    
+
     def mark_actors_as_modified(self):
         """Mark as modified"""
         self.project.mark_as_modified(ACTOR_LIST)
@@ -168,6 +173,9 @@ class ListsModule(AbstractModule):
 
     def get_monster_md(self) -> Md:
         return self.project.get_module('monster').monster_md
+
+    def get_waza_p(self) -> WazaP:
+        return self.waza_p_bin
 
     def get_starter_default_ids(self) -> Tuple[int, int]:
         """Returns players & partner default starters"""

--- a/skytemple/module/lists/module.py
+++ b/skytemple/module/lists/module.py
@@ -23,6 +23,7 @@ from skytemple.core.open_request import OpenRequest, REQUEST_TYPE_DUNGEON_MUSIC
 from skytemple.core.rom_project import RomProject, BinaryName
 from skytemple.core.ui_utils import recursive_up_item_store_mark_as_modified, generate_item_store_row_label
 from skytemple.module.lists.controller.dungeon_music import DungeonMusicController
+from skytemple.module.lists.controller.guest_pokemon import GuestPokemonController
 from skytemple.module.lists.controller.main import MainController, GROUND_LISTS
 from skytemple.module.lists.controller.actor_list import ActorListController
 from skytemple.module.lists.controller.misc_settings import MiscSettingsController
@@ -36,6 +37,8 @@ from skytemple_files.data.data_cd.handler import DataCDHandler
 from skytemple_files.data.md.model import Md
 from skytemple_files.hardcoded.dungeon_music import HardcodedDungeonMusic, DungeonMusicEntry
 from skytemple_files.hardcoded.dungeons import MapMarkerPlacement, HardcodedDungeons
+from skytemple_files.hardcoded.guest_pokemon import ExtraDungeonDataList, ExtraDungeonDataEntry, GuestPokemon, \
+    GuestPokemonList
 from skytemple_files.hardcoded.personality_test_starters import HardcodedPersonalityTestStarters
 from skytemple_files.hardcoded.default_starters import HardcodedDefaultStarters
 from skytemple_files.hardcoded.rank_up_table import Rank, HardcodedRankUpTable
@@ -70,6 +73,7 @@ class ListsModule(AbstractModule):
         self._menu_list_tree_iter = None
         self._dungeon_music_tree_iter = None
         self._misc_settings_tree_iter = None
+        self._guest_pokemon_root_iter = None
 
     def load_tree_items(self, item_store: TreeStore, root_node):
         root = item_store.append(root_node, [
@@ -102,6 +106,9 @@ class ListsModule(AbstractModule):
         self._misc_settings_tree_iter = item_store.append(root, [
             'skytemple-view-list-symbolic', _('Misc. Settings'), self, MiscSettingsController, 0, False, '', True
         ])
+        self._guest_pokemon_root_iter = item_store.append(root, [
+            'skytemple-e-monster-symbolic', _('Guest pokémon'), self, GuestPokemonController, 0, False, '', True
+        ])
         generate_item_store_row_label(item_store[root])
         generate_item_store_row_label(item_store[self._actor_tree_iter])
         generate_item_store_row_label(item_store[self._starters_tree_iter])
@@ -112,6 +119,7 @@ class ListsModule(AbstractModule):
         generate_item_store_row_label(item_store[self._sp_effects_tree_iter])
         generate_item_store_row_label(item_store[self._dungeon_music_tree_iter])
         generate_item_store_row_label(item_store[self._misc_settings_tree_iter])
+        generate_item_store_row_label(item_store[self._guest_pokemon_root_iter])
         self._tree_model = item_store
 
     def handle_request(self, request: OpenRequest) -> Optional[TreeIter]:
@@ -143,6 +151,9 @@ class ListsModule(AbstractModule):
         # Mark as modified in tree
         row = self._tree_model[self._actor_tree_iter]
         recursive_up_item_store_mark_as_modified(row)
+
+    def has_edit_extra_pokemon(self):
+        return self.project.is_patch_applied("EditExtraPokemon")
 
     def mark_str_as_modified(self):
         self.project.get_string_provider().mark_as_modified()
@@ -312,4 +323,24 @@ class ListsModule(AbstractModule):
         self.project.modify_binary(BinaryName.OVERLAY_10, lambda ov10: HardcodedDungeonMusic.set_random_music_list(random, ov10, config))
 
         row = self._tree_model[self._dungeon_music_tree_iter]
+        recursive_up_item_store_mark_as_modified(row)
+
+    def set_extra_dungeon_data(self, lst: List[ExtraDungeonDataEntry]):
+        """Updates the extra dungeon data list"""
+        def update(arm9):
+            static_data = self.project.get_rom_module().get_static_data()
+            ExtraDungeonDataList.write(lst, arm9, static_data)
+        self.project.modify_binary(BinaryName.ARM9, update)
+
+        row = self._tree_model[self._guest_pokemon_root_iter]
+        recursive_up_item_store_mark_as_modified(row)
+
+    def set_guest_pokemon_data(self, lst: List[GuestPokemon]):
+        """Updates the guest pokémon data list"""
+        def update(arm9):
+            static_data = self.project.get_rom_module().get_static_data()
+            GuestPokemonList.write(lst, arm9, static_data)
+        self.project.modify_binary(BinaryName.ARM9, update)
+
+        row = self._tree_model[self._guest_pokemon_root_iter]
         recursive_up_item_store_mark_as_modified(row)


### PR DESCRIPTION
Adds a new screen under "Lists" that can be used to change which dungeons add guest pokémon to your team when they are uncleared and what pokémon they add. The new screen also allows changing some dungeon data that was previously hardcoded by ID, such as which dungeons have Hidden Land-like restrictions active.

A potential improvement to the screen would be changing the guest columns to use a dropdown listing all the guest data entries instead of an integer.