### PR TITLE
Quick fix for the guest pokémon list

### DIFF
--- a/skytemple/module/lists/controller/guest_pokemon.py
+++ b/skytemple/module/lists/controller/guest_pokemon.py
@@ -95,7 +95,7 @@ class GuestPokemonController(ListBaseController):
         store.append([
             str(len(store)), "0", self._get_monster_display_name(0), "0", self._get_move_display_name(0),
             self._get_move_display_name(0), self._get_move_display_name(0), self._get_move_display_name(0),
-            "1", "1", "1", "0", "0", "0", "0", "0", "0"
+            "1", "1", "1", "0", "0", "0", "0", "0", "0", None
         ])
         self._update_free_entries_left()
         self._save_guest_pokemon_data()


### PR DESCRIPTION
After pokémon icons were added to the guest pokémon menu in https://github.com/SkyTemple/skytemple/commit/9ab21deadc57e1775979c9be4a5fe616ac7799c7#diff-406df4a784b1d6c1871a44fb259f9008addd17dbf4fff9d76c4a54276794407a, SkyTemple crashes when trying to add a new entry because no value has been specified for the icon.
This change just sets a null value, so no icon will be displayed until the pokémon is changed or the view is reloaded.
Another option would be setting the icon of pokémon #0, but I don't know how to get the `idx` parameter that is needed for that. Feel free to do that instead if you prefer.