### PR TITLE
Rectangle draw option for background maps + dimension fix

### DIFF
--- a/skytemple/module/map_bg/controller/bg.py
+++ b/skytemple/module/map_bg/controller/bg.py
@@ -1,4 +1,4 @@
-#  Copyright 2020-2021 Parakoopa and the SkyTemple Contributors
+#  Copyright 2020-2021 Capypara and the SkyTemple Contributors
 #
 #  This file is part of SkyTemple.
 #

--- a/skytemple/module/map_bg/controller/bg_menu.py
+++ b/skytemple/module/map_bg/controller/bg_menu.py
@@ -185,12 +185,12 @@ class BgMenuController:
                     int(map_width_tiles.get_text()), int(map_height_tiles.get_text()),
                 )
                 for x in params:
-                    if x<0 or x>=256:
+                    if x<=0 or x>=256:
                         raise ValueError("Invalid parameter.")
             except ValueError:
                 md = SkyTempleMessageDialog(MainController.window(),
                                             Gtk.DialogFlags.DESTROY_WITH_PARENT, Gtk.MessageType.ERROR,
-                                            Gtk.ButtonsType.OK, _("Incorrect values.\nOnly enter numbers from 0 to 255 for chunks and tiles dimensions."))
+                                            Gtk.ButtonsType.OK, _("Incorrect values.\nOnly enter numbers from 1 to 255 for chunks and tiles dimensions."))
                 md.set_position(Gtk.WindowPosition.CENTER)
                 md.run()
                 md.destroy()

--- a/skytemple/module/map_bg/controller/bg_menu.py
+++ b/skytemple/module/map_bg/controller/bg_menu.py
@@ -1,5 +1,5 @@
 """Sub-controller for the map bg menu."""
-#  Copyright 2020-2021 Parakoopa and the SkyTemple Contributors
+#  Copyright 2020-2021 Capypara and the SkyTemple Contributors
 #
 #  This file is part of SkyTemple.
 #

--- a/skytemple/module/map_bg/controller/bg_menu.py
+++ b/skytemple/module/map_bg/controller/bg_menu.py
@@ -1,5 +1,5 @@
 """Sub-controller for the map bg menu."""
-#  Copyright 2020-2021 Capypara and the SkyTemple Contributors
+#  Copyright 2020-2021 Parakoopa and the SkyTemple Contributors
 #
 #  This file is part of SkyTemple.
 #
@@ -184,10 +184,13 @@ class BgMenuController:
                     int(map_width_chunks.get_text()), int(map_height_chunks.get_text()),
                     int(map_width_tiles.get_text()), int(map_height_tiles.get_text()),
                 )
+                for x in params:
+                    if x<0 or x>=256:
+                        raise ValueError("Invalid parameter.")
             except ValueError:
                 md = SkyTempleMessageDialog(MainController.window(),
                                             Gtk.DialogFlags.DESTROY_WITH_PARENT, Gtk.MessageType.ERROR,
-                                            Gtk.ButtonsType.OK, _("Please only enter numbers for the map size."))
+                                            Gtk.ButtonsType.OK, _("Incorrect values.\nOnly enter numbers from 0 to 255 for chunks and tiles dimensions."))
                 md.set_position(Gtk.WindowPosition.CENTER)
                 md.run()
                 md.destroy()

--- a/skytemple/module/map_bg/controller/map_bg.glade
+++ b/skytemple/module/map_bg/controller/map_bg.glade
@@ -136,6 +136,7 @@
           <object class="GtkToggleToolButton" id="tb_bg_color">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
+            <property name="tooltip-text" translatable="yes">Toggle Background Color</property>
             <property name="is-important">True</property>
             <property name="label" translatable="yes">BG Color</property>
             <property name="use-underline">True</property>

--- a/skytemple/module/map_bg/controller/map_bg.glade
+++ b/skytemple/module/map_bg/controller/map_bg.glade
@@ -136,7 +136,6 @@
           <object class="GtkToggleToolButton" id="tb_bg_color">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
-            <property name="tooltip-text" translatable="yes">Toggle Background Color</property>
             <property name="is-important">True</property>
             <property name="label" translatable="yes">BG Color</property>
             <property name="use-underline">True</property>
@@ -167,6 +166,7 @@
             <property name="label" translatable="yes">Go to Scenes</property>
             <property name="use-underline">True</property>
             <property name="icon-name">skytemple-go-next-symbolic</property>
+            <signal name="clicked" handler="on_tb_goto_scene_clicked" swapped="no"/>
           </object>
           <packing>
             <property name="expand">False</property>

--- a/skytemple/module/map_bg/controller/map_bg.glade
+++ b/skytemple/module/map_bg/controller/map_bg.glade
@@ -111,6 +111,28 @@
           </packing>
         </child>
         <child>
+          <object class="GtkToggleToolButton" id="tb_rectangle">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="label" translatable="yes">Rect</property>
+            <property name="use-underline">True</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="homogeneous">True</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkSeparatorToolItem">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="homogeneous">False</property>
+          </packing>
+        </child>
+        <child>
           <object class="GtkToggleToolButton" id="tb_bg_color">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
@@ -145,7 +167,6 @@
             <property name="label" translatable="yes">Go to Scenes</property>
             <property name="use-underline">True</property>
             <property name="icon-name">skytemple-go-next-symbolic</property>
-            <signal name="clicked" handler="on_tb_goto_scene_clicked" swapped="no"/>
           </object>
           <packing>
             <property name="expand">False</property>

--- a/skytemple/module/map_bg/drawer.py
+++ b/skytemple/module/map_bg/drawer.py
@@ -88,9 +88,8 @@ class Drawer:
         self.scale = 1
 
         self.drawing_is_active = False
-
-    # noinspection PyAttributeOutsideInit
-    def reset(self, bma, bpa_durations, pal_ani_durations, chunks_surfaces):
+    
+    def reset_bma(self, bma):
         if isinstance(bma, Bma):
             self.tiling_width = bma.tiling_width
             self.tiling_height = bma.tiling_height
@@ -113,6 +112,10 @@ class Drawer:
             self.collision1 = None
             self.collision2 = None
             self.data_layer = None
+
+    # noinspection PyAttributeOutsideInit
+    def reset(self, bma, bpa_durations, pal_ani_durations, chunks_surfaces):
+        self.reset_bma(bma)
 
         self.animation_context = AnimationContext(chunks_surfaces, bpa_durations, pal_ani_durations)
         self._tileset_drawer_overlay: Optional[MapTilesetOverlay] = None


### PR DESCRIPTION
- Adds a "Rect" toggle button in menu bar to draw a filled rectangle for collision data and chunks instead of single points.
TODO: Use an icon instead of text for the "Rect" button.
- Also prevents from trying to set invalid tiles and chunks dimensions.