### PR TITLE
UI Support for editing Idle Animation Type + Item Sort Keys

### DIFF
--- a/skytemple/module/monster/controller/monster.glade
+++ b/skytemple/module/monster/controller/monster.glade
@@ -1299,7 +1299,7 @@ If you choose to export both genders, upon import the matching gender entry will
                       </packing>
                     </child>
                     <child>
-                      <!-- n-columns=4 n-rows=7 -->
+                      <!-- n-columns=4 n-rows=8 -->
                       <object class="GtkGrid">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
@@ -1388,7 +1388,7 @@ If you choose to export both genders, upon import the matching gender entry will
                             <property name="visible">True</property>
                             <property name="can-focus">False</property>
                             <property name="halign">end</property>
-                            <property name="label" translatable="yes">Personality:</property>
+                            <property name="label" translatable="yes">Talk Group:</property>
                           </object>
                           <packing>
                             <property name="left-attach">0</property>
@@ -1523,6 +1523,31 @@ If you choose to export both genders, upon import the matching gender entry will
                             <property name="left-attach">2</property>
                             <property name="top-attach">3</property>
                             <property name="width">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <property name="halign">end</property>
+                            <property name="label" translatable="yes">Idle Animation Type:</property>
+                          </object>
+                          <packing>
+                            <property name="left-attach">0</property>
+                            <property name="top-attach">7</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkEntry" id="entry_idle_anim">
+                            <property name="visible">True</property>
+                            <property name="can-focus">True</property>
+                            <property name="width-chars">10</property>
+                            <signal name="changed" handler="on_entry_idle_anim_changed" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="left-attach">1</property>
+                            <property name="top-attach">7</property>
+                            <property name="width">3</property>
                           </packing>
                         </child>
                       </object>

--- a/skytemple/module/monster/controller/monster.glade
+++ b/skytemple/module/monster/controller/monster.glade
@@ -1538,16 +1538,35 @@ If you choose to export both genders, upon import the matching gender entry will
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkEntry" id="entry_idle_anim">
+                          <object class="GtkButton" id="btn_help_idle">
                             <property name="visible">True</property>
                             <property name="can-focus">True</property>
-                            <property name="width-chars">10</property>
-                            <signal name="changed" handler="on_entry_idle_anim_changed" swapped="no"/>
+                            <property name="receives-default">True</property>
+                            <property name="valign">center</property>
+                            <signal name="clicked" handler="on_btn_help_idle_clicked" swapped="no"/>
+                            <child>
+                              <object class="GtkImage">
+                                <property name="visible">True</property>
+                                <property name="can-focus">False</property>
+                                <property name="icon-name">skytemple-help-about-symbolic</property>
+                              </object>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="left-attach">3</property>
+                            <property name="top-attach">7</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkComboBox" id="cb_idle_anim">
+                            <property name="visible">True</property>
+                            <property name="can-focus">False</property>
+                            <signal name="changed" handler="on_cb_idle_anim_changed" swapped="no"/>
                           </object>
                           <packing>
                             <property name="left-attach">1</property>
                             <property name="top-attach">7</property>
-                            <property name="width">3</property>
+                            <property name="width">2</property>
                           </packing>
                         </child>
                       </object>

--- a/skytemple/module/monster/controller/monster.py
+++ b/skytemple/module/monster/controller/monster.py
@@ -210,6 +210,12 @@ class MonsterController(AbstractController):
             self.module.set_personality(self.item_id, int(w.get_text()))
         except ValueError:
             pass
+    
+    def on_entry_idle_anim_changed(self, w, *args):
+        try:
+            self.module.set_idle_anim_type(self.item_id, int(w.get_text()))
+        except ValueError:
+            pass
         
     def on_entry_sprite_index_changed(self, w, *args):
         self._update_from_entry(w)
@@ -693,7 +699,7 @@ Each drop type x has a chance of (x rate)/(sum of all the rates) to be selected.
                     ]
                 )
 
-        names, md_gender1, md_gender2, moveset, moveset2, stats, portraits, portraits2, personality1, personality2 = self.module.get_export_data(self.entry)
+        names, md_gender1, md_gender2, moveset, moveset2, stats, portraits, portraits2, personality1, personality2, idle_anim1, idle_anim2 = self.module.get_export_data(self.entry)
         we_are_gender1 = md_gender1 == self.entry
 
         if self.module.project.is_patch_applied('ExpandPokeList'):
@@ -701,6 +707,7 @@ Each drop type x has a chance of (x rate)/(sum of all the rates) to be selected.
             md_gender2 = None
             portraits2 = None
             personality2 = None
+            idle_anim2 = None
 
         if md_gender2 is None:
             sw: Gtk.Switch = self.builder.get_object('export_type_other_gender')
@@ -770,7 +777,7 @@ Each drop type x has a chance of (x rate)/(sum of all the rates) to be selected.
             xml = monster_xml_export(
                 self.module.project.get_rom_module().get_static_data().game_version,
                 md_gender1, md_gender2, names, moveset, moveset2, stats, portraits, portraits2,
-                personality1, personality2
+                personality1, personality2, idle_anim1, idle_anim2
             )
 
             # 1. Export to file
@@ -932,6 +939,11 @@ Each drop type x has a chance of (x rate)/(sum of all the rates) to be selected.
                                                                        langs[lang_id]))
 
         # Stats
+        a = self.module.get_idle_anim_type(self.item_id)
+        if a==None:
+            self.builder.get_object('entry_idle_anim').set_sensitive(False)
+        else:
+            self._set_entry('entry_idle_anim', a)
         self._set_entry('entry_personality', self.module.get_personality(self.item_id))
         self._set_entry('entry_unk31', self.entry.unk31)
         self._set_entry('entry_national_pokedex_number', self.entry.national_pokedex_number)

--- a/skytemple/module/monster/controller/monster.py
+++ b/skytemple/module/monster/controller/monster.py
@@ -39,6 +39,7 @@ from skytemple_files.data.md.model import Gender, PokeType, MovementType, IQGrou
     AdditionalRequirement, MdProperties, ShadowSize, MONSTER_BIN, MdEntry
 from skytemple.controller.main import MainController as SkyTempleMainController
 from skytemple_files.data.monster_xml import monster_xml_export
+from skytemple_files.hardcoded.monster_sprite_data_table import IdleAnimType
 from skytemple_files.common.i18n_util import f, _
 
 if TYPE_CHECKING:
@@ -211,9 +212,10 @@ class MonsterController(AbstractController):
         except ValueError:
             pass
     
-    def on_entry_idle_anim_changed(self, w, *args):
+    def on_cb_idle_anim_changed(self, w, *args):
         try:
-            self.module.set_idle_anim_type(self.item_id, int(w.get_text()))
+            val = w.get_model()[w.get_active_iter()][0]
+            self.module.set_idle_anim_type(self.item_id, IdleAnimType(val))
         except ValueError:
             pass
         
@@ -367,6 +369,18 @@ class MonsterController(AbstractController):
         self._update_param_label()
         self.mark_as_modified()
 
+    def on_btn_help_idle_clicked(self, w, *args):
+        md = SkyTempleMessageDialog(
+            MainController.window(),
+            Gtk.DialogFlags.DESTROY_WITH_PARENT, Gtk.MessageType.INFO,
+            Gtk.ButtonsType.OK,
+            _("This value can only be edited with the ChangePokemonGroundAnim patch. \n"
+              "This tells how idle animations should be handled for each pokemon. "),
+            title=_("Idle Animation Types")
+        )
+        md.run()
+        md.destroy()
+    
     def on_btn_help_evo_params_clicked(self, w, *args):
         md = SkyTempleMessageDialog(
             MainController.window(),
@@ -914,6 +928,8 @@ Each drop type x has a chance of (x rate)/(sum of all the rates) to be selected.
         self._comboxbox_for_enum(['cb_evo_method'], EvolutionMethod)
         # Additional Requirement
         self._comboxbox_for_enum(['cb_evo_param2'], AdditionalRequirement)
+        # Idle Animation Type
+        self._comboxbox_for_enum(['cb_idle_anim'], IdleAnimType)
         
         # Shadow Size
         self._comboxbox_for_enum(['cb_shadow_size'], ShadowSize)
@@ -941,9 +957,9 @@ Each drop type x has a chance of (x rate)/(sum of all the rates) to be selected.
         # Stats
         a = self.module.get_idle_anim_type(self.item_id)
         if a==None:
-            self.builder.get_object('entry_idle_anim').set_sensitive(False)
+            self.builder.get_object('cb_idle_anim').set_sensitive(False)
         else:
-            self._set_entry('entry_idle_anim', a)
+            self._set_cb('cb_idle_anim', a.value)
         self._set_entry('entry_personality', self.module.get_personality(self.item_id))
         self._set_entry('entry_unk31', self.entry.unk31)
         self._set_entry('entry_national_pokedex_number', self.entry.national_pokedex_number)

--- a/skytemple/module/monster/module.py
+++ b/skytemple/module/monster/module.py
@@ -38,7 +38,7 @@ from skytemple_files.data.md.model import Md, MdEntry, MdProperties, ShadowSize
 from skytemple_files.data.monster_xml import monster_xml_import, GenderedConvertEntry
 from skytemple_files.data.waza_p.model import WazaP
 from skytemple_files.graphics.kao.model import KaoImage, SUBENTRIES, Kao
-from skytemple_files.hardcoded.monster_sprite_data_table import HardcodedMonsterSpriteDataTable, HardcodedMonsterGroundIdleAnimTable
+from skytemple_files.hardcoded.monster_sprite_data_table import HardcodedMonsterSpriteDataTable, HardcodedMonsterGroundIdleAnimTable, IdleAnimType
 from skytemple_files.common.i18n_util import _
 from skytemple_files.common.util import normalize_string
 MONSTER_MD_FILE = 'BALANCE/monster.md'

--- a/skytemple/module/monster/module.py
+++ b/skytemple/module/monster/module.py
@@ -38,7 +38,7 @@ from skytemple_files.data.md.model import Md, MdEntry, MdProperties, ShadowSize
 from skytemple_files.data.monster_xml import monster_xml_import, GenderedConvertEntry
 from skytemple_files.data.waza_p.model import WazaP
 from skytemple_files.graphics.kao.model import KaoImage, SUBENTRIES, Kao
-from skytemple_files.hardcoded.monster_sprite_data_table import HardcodedMonsterSpriteDataTable
+from skytemple_files.hardcoded.monster_sprite_data_table import HardcodedMonsterSpriteDataTable, HardcodedMonsterGroundIdleAnimTable
 from skytemple_files.common.i18n_util import _
 from skytemple_files.common.util import normalize_string
 MONSTER_MD_FILE = 'BALANCE/monster.md'
@@ -223,6 +223,26 @@ class MonsterModule(AbstractModule):
         controller = LevelUpController(self, item_id)
         return controller.get_view(), controller
 
+    def set_idle_anim_type(self, item_id, value):
+        """Set idle value of the monster"""
+        if self.project.is_patch_applied('ChangePokemonGroundAnim'):
+            def update(ov11):
+                static_data = self.project.get_rom_module().get_static_data()
+                values = HardcodedMonsterGroundIdleAnimTable.get(ov11, static_data)
+                values[item_id] = value
+                HardcodedMonsterGroundIdleAnimTable.set(values, ov11, static_data)
+            self.project.modify_binary(BinaryName.OVERLAY_11, update)
+            self._mark_as_modified_in_tree(item_id)
+    
+    def get_idle_anim_type(self, item_id):
+        """Get idle value of the monster"""
+        if self.project.is_patch_applied('ChangePokemonGroundAnim'):
+            ov11 = self.project.get_binary(BinaryName.OVERLAY_11)
+            static_data = self.project.get_rom_module().get_static_data()
+            return HardcodedMonsterGroundIdleAnimTable.get(ov11, static_data)[item_id]
+        else:
+            return None
+    
     def set_personality(self, item_id, value):
         """Set personality value of the monster"""
         self.tbl_talk.set_monster_personality(item_id, value)
@@ -316,7 +336,9 @@ class MonsterModule(AbstractModule):
         portraits, portraits2 = self.get_portraits_for_export(stats_and_portraits_id)
         return names, md_gender1, md_gender2, moveset, moveset2, stats, portraits, portraits2, \
                self.get_personality(md_gender1.md_index), \
-               self.get_personality(md_gender2.md_index) if md_gender2 is not None else None
+               self.get_personality(md_gender2.md_index) if md_gender2 is not None else None, \
+               self.get_idle_anim_type(md_gender1.md_index), \
+               self.get_idle_anim_type(md_gender2.md_index) if md_gender2 is not None else None
 
     def update_monster_sort_lists(self, lang):
         sp = self.project.get_string_provider()
@@ -340,7 +362,7 @@ class MonsterModule(AbstractModule):
 
         for monster_id in selected_monsters:
             entry = self.get_entry(monster_id)
-            names, md_gender1, md_gender2, moveset, moveset2, stats, portraits, portraits2, personality1, personality2 = self.get_export_data(entry)
+            names, md_gender1, md_gender2, moveset, moveset2, stats, portraits, portraits2, personality1, personality2, idle_anim1, idle_anim2 = self.get_export_data(entry)
             we_are_gender1 = monster_id < MdProperties.NUM_ENTITIES
 
             md_gender1_imp = md_gender1
@@ -352,12 +374,14 @@ class MonsterModule(AbstractModule):
                     md_gender2_imp = None
                     portraits2_imp = None
                     personality2 = None
+                    idle_anim2 = None
                 else:
                     md_gender1_imp = None
                     portraits1_imp = None
                     personality1 = None
-            md_gender1_imp_wrapped = GenderedConvertEntry(md_gender1, personality1)
-            md_gender2_imp_wrapped = GenderedConvertEntry(md_gender2, personality2)
+                    idle_anim1 = None
+            md_gender1_imp_wrapped = GenderedConvertEntry(md_gender1, personality1, idle_anim1)
+            md_gender2_imp_wrapped = GenderedConvertEntry(md_gender2, personality2, idle_anim2)
 
             monster_xml_import(
                 xml, md_gender1_imp_wrapped, md_gender2_imp_wrapped,
@@ -368,12 +392,18 @@ class MonsterModule(AbstractModule):
                 if we_are_gender1:
                     if md_gender1_imp_wrapped.personality is not None:
                         self.set_personality(md_gender1.md_index, md_gender1_imp_wrapped.personality)
+                    if md_gender1_imp_wrapped.idle_anim is not None:
+                        self.set_idle_anim_type(md_gender1.md_index, md_gender1_imp_wrapped.idle_anim)
                 else:
                     if md_gender2_imp_wrapped.personality is not None:
                         self.set_personality(md_gender2.md_index, md_gender2_imp_wrapped.personality)
+                    if md_gender2_imp_wrapped.idle_anim is not None:
+                        self.set_idle_anim_type(md_gender2.md_index, md_gender2_imp_wrapped.idle_anim)
             else:
                 if md_gender1_imp_wrapped.personality is not None:
                     self.set_personality(md_gender1.md_index, md_gender1_imp_wrapped.personality)
+                if md_gender1_imp_wrapped.idle_anim is not None:
+                    self.set_idle_anim_type(md_gender1.md_index, md_gender1_imp_wrapped.idle_anim)
             if stats:
                 self.set_m_level_bin_entry(getattr(entry, b_attr) - 1, stats)
             if names:

--- a/skytemple/module/moves_items/controller/item_keys.glade
+++ b/skytemple/module/moves_items/controller/item_keys.glade
@@ -1,0 +1,368 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.38.2 -->
+<interface>
+  <requires lib="gtk+" version="3.22"/>
+  <object class="GtkListStore" id="cb_store_lang">
+    <columns>
+      <!-- column-name locale -->
+      <column type="gchararray"/>
+      <!-- column-name name -->
+      <column type="gchararray"/>
+    </columns>
+  </object>
+  <object class="GtkDialog" id="dialog_add_remove">
+    <property name="can-focus">False</property>
+    <property name="type-hint">dialog</property>
+    <child internal-child="vbox">
+      <object class="GtkBox">
+        <property name="can-focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">2</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox">
+            <property name="can-focus">False</property>
+            <property name="layout-style">end</property>
+            <child>
+              <object class="GtkButton" id="btn_ok">
+                <property name="label">gtk-ok</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <property name="use-stock">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="btn_cancel">
+                <property name="label">gtk-cancel</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <property name="use-stock">True</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="lbl_add_remove_title">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="halign">start</property>
+            <property name="margin-top">10</property>
+            <property name="margin-bottom">10</property>
+            <property name="label" translatable="yes">Item/Remove Key Placeholder Title</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkSpinButton" id="id_key_add_remove">
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <signal name="value-changed" handler="on_id_key_add_remove_value_changed" swapped="no"/>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="lbl_add_remove_desc">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="halign">start</property>
+            <property name="margin-top">15</property>
+            <property name="margin-bottom">15</property>
+            <property name="label" translatable="yes">Item/Remove Key Placeholder Description</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">3</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <action-widgets>
+      <action-widget response="-5">btn_ok</action-widget>
+      <action-widget response="-6">btn_cancel</action-widget>
+    </action-widgets>
+  </object>
+  <object class="GtkListStore" id="tree_store">
+    <columns>
+      <!-- column-name sort_key -->
+      <column type="guint"/>
+      <!-- column-name item_name -->
+      <column type="gchararray"/>
+      <!-- column-name item_id -->
+      <column type="guint"/>
+    </columns>
+  </object>
+  <object class="GtkBox" id="box_list">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="orientation">vertical</property>
+    <child>
+      <object class="GtkAlignment">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="xscale">0.8000000119209289</property>
+        <property name="yscale">0.8000000119209289</property>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="orientation">vertical</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="margin-top">64</property>
+                <property name="label" translatable="yes">Item Keys</property>
+                <style>
+                  <class name="skytemple-view-main-label"/>
+                </style>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="halign">center</property>
+                <property name="homogeneous">True</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="halign">end</property>
+                    <property name="label" translatable="yes">Language: </property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkComboBox" id="cb_lang">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="model">cb_store_lang</property>
+                    <signal name="changed" handler="on_lang_changed" swapped="no"/>
+                    <child>
+                      <object class="GtkCellRendererText"/>
+                      <attributes>
+                        <attribute name="text">1</attribute>
+                      </attributes>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">3</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkScrolledWindow">
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="margin-top">20</property>
+                <property name="margin-bottom">20</property>
+                <property name="shadow-type">in</property>
+                <child>
+                  <object class="GtkTreeView" id="tree">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="model">tree_store</property>
+                    <property name="search-column">0</property>
+                    <child internal-child="selection">
+                      <object class="GtkTreeSelection"/>
+                    </child>
+                    <child>
+                      <object class="GtkTreeViewColumn">
+                        <property name="title" translatable="yes">Sort Key</property>
+                        <property name="alignment">0.009999999776482582</property>
+                        <child>
+                          <object class="GtkCellRendererText" id="sort_key">
+                            <property name="editable">True</property>
+                            <signal name="edited" handler="on_sort_key_edited" swapped="no"/>
+                          </object>
+                          <attributes>
+                            <attribute name="text">0</attribute>
+                          </attributes>
+                        </child>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkTreeViewColumn">
+                        <property name="title" translatable="yes">Item Name</property>
+                        <child>
+                          <object class="GtkCellRendererText" id="item_name"/>
+                          <attributes>
+                            <attribute name="text">1</attribute>
+                          </attributes>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="hexpand">True</property>
+                <child>
+                  <object class="GtkButton" id="btn_insert">
+                    <property name="label" translatable="yes">Insert Key...</property>
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">True</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
+                    <property name="hexpand">True</property>
+                    <signal name="clicked" handler="on_btn_insert_clicked" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkButton" id="btn_remove">
+                    <property name="label" translatable="yes">Remove Key...</property>
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">True</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
+                    <property name="hexpand">True</property>
+                    <signal name="clicked" handler="on_btn_remove_clicked" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkButton" id="btn_fix">
+                    <property name="label" translatable="yes">Add Missing Keys</property>
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">True</property>
+                    <property name="halign">center</property>
+                    <property name="valign">center</property>
+                    <property name="hexpand">True</property>
+                    <signal name="clicked" handler="on_btn_fix_clicked" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">3</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="label" translatable="yes">More Info: </property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkButton" id="btn_help">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">True</property>
+                    <property name="halign">start</property>
+                    <property name="valign">center</property>
+                    <signal name="clicked" handler="on_btn_help_clicked" swapped="no"/>
+                    <child>
+                      <object class="GtkImage">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="icon-name">skytemple-help-about-symbolic</property>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">4</property>
+              </packing>
+            </child>
+          </object>
+        </child>
+      </object>
+      <packing>
+        <property name="expand">True</property>
+        <property name="fill">True</property>
+        <property name="position">1</property>
+      </packing>
+    </child>
+    <style>
+      <class name="back_illust"/>
+      <class name="bboard"/>
+    </style>
+  </object>
+</interface>

--- a/skytemple/module/moves_items/controller/item_keys.py
+++ b/skytemple/module/moves_items/controller/item_keys.py
@@ -29,7 +29,7 @@ from skytemple.core.string_provider import StringType
 from skytemple_files.common.i18n_util import _
 
 if TYPE_CHECKING:
-    from skytemple.module.lists.module import ListsModule
+    from skytemple.module.moves_items.module import MovesItemsModule
 
 PATTERN_ITEM_ENTRY = re.compile(r'.*\(#(\d+)\).*')
 logger = logging.getLogger(__name__)

--- a/skytemple/module/moves_items/controller/item_keys.py
+++ b/skytemple/module/moves_items/controller/item_keys.py
@@ -1,0 +1,215 @@
+#  Copyright 2020-2021 Capypara and the SkyTemple Contributors
+#
+#  This file is part of SkyTemple.
+#
+#  SkyTemple is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 3 of the License, or
+#  (at your option) any later version.
+#
+#  SkyTemple is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
+import logging
+import re
+import sys
+from typing import TYPE_CHECKING, Optional, List
+
+from gi.repository import Gtk
+
+from skytemple.core.error_handler import display_error
+from skytemple.core.module_controller import AbstractController
+from skytemple.controller.main import MainController
+from skytemple.core.message_dialog import SkyTempleMessageDialog
+from skytemple.core.string_provider import StringType
+from skytemple_files.common.i18n_util import _
+
+if TYPE_CHECKING:
+    from skytemple.module.lists.module import ListsModule
+
+PATTERN_ITEM_ENTRY = re.compile(r'.*\(#(\d+)\).*')
+logger = logging.getLogger(__name__)
+
+
+class ItemKeysController(AbstractController):
+    def __init__(self, module: 'MovesItemsModule', *args):
+        super().__init__(module, *args)
+        self.module = module
+        self._string_provider = module.project.get_string_provider()
+
+    def get_view(self) -> Gtk.Widget:
+        self.builder = self._get_builder(__file__, 'item_keys.glade')
+        lst: Gtk.Box = self.builder.get_object('box_list')
+
+        self._init_combos()
+        self.on_lang_changed()
+        self.builder.connect_signals(self)
+        return lst
+
+    def _init_combos(self):
+        # Init available languages
+        cb_store: Gtk.ListStore = self.builder.get_object('cb_store_lang')
+        cb: Gtk.ComboBoxText = self.builder.get_object('cb_lang')
+        # Init combobox
+        cb_store.clear()
+        for lang in self._string_provider.get_languages():
+            cb_store.append([lang.locale, lang.name_localized])
+        cb.set_active(0)
+
+
+    def on_btn_help_clicked(self, *args):
+        md = SkyTempleMessageDialog(MainController.window(),
+                                    Gtk.DialogFlags.DESTROY_WITH_PARENT, Gtk.MessageType.INFO,
+                                    Gtk.ButtonsType.OK,
+                                    _("""Sort keys are used to sort items in your inventory when using the sort feature in game.
+The game sorts items starting from the one with the lowest key to the highest.
+Several items can have the same key; this means they will be mixed together while sorting (e.g. Lookalike items).
+Only keys from 0 to 2047 should be used."""))
+        md.run()
+        md.destroy()
+
+    def on_lang_changed(self, *args):
+        cb_store: Gtk.ListStore = self.builder.get_object('cb_store_lang')
+        cb: Gtk.ComboBoxText = self.builder.get_object('cb_lang')
+        self._current_lang = cb_store[cb.get_active_iter()][0]
+        self._refresh_list()
+
+    def _regenerate_list(self):
+        tree_store: Gtk.ListStore = self.builder.get_object('tree_store')
+
+        new_list = []
+        for l in tree_store:
+            new_list.append((l[2],l[0]))
+        new_list.sort()
+        new_list = [x[1] for x in new_list]
+        self.module.set_i2n(self._current_lang, new_list)
+        self._refresh_list()
+        
+    def on_sort_key_edited(self, widget, path, text):
+        try:
+            tree_store: Gtk.ListStore = self.builder.get_object('tree_store')
+            tree_store[path][0] = int(text)
+        except ValueError:
+            return
+        
+        self._regenerate_list()
+
+    def _get_max_key(self):
+        tree_store: Gtk.ListStore = self.builder.get_object('tree_store')
+        new_list = []
+        for l in tree_store:
+            new_list.append(l[0])
+        return max(new_list)
+        
+    def _setup_dialog(self):
+        dialog: Gtk.Dialog = self.builder.get_object('dialog_add_remove')
+        
+        self.builder.get_object('id_key_add_remove').set_increments(1,1)
+        self.builder.get_object('id_key_add_remove').set_range(0, self._get_max_key())
+        self.builder.get_object('id_key_add_remove').set_text(str(0))
+        
+        dialog.set_attached_to(MainController.window())
+        dialog.set_transient_for(MainController.window())
+
+        return dialog
+        
+    def on_btn_fix_clicked(self, *args):
+        tree_store: Gtk.ListStore = self.builder.get_object('tree_store')
+        new_list = []
+        for l in tree_store:
+            new_list.append((l[2],l[0]))
+        new_list.sort()
+        new_list = [x[1] for x in new_list]
+        while len(new_list)<1400:
+            new_list.append(0)
+        self.module.set_i2n(self._current_lang, new_list)
+        
+        md = SkyTempleMessageDialog(MainController.window(),
+                                    Gtk.DialogFlags.DESTROY_WITH_PARENT, Gtk.MessageType.INFO,
+                                    Gtk.ButtonsType.OK,
+                                    _("Keys have now been added for all the 1400 items."))
+        md.run()
+        md.destroy()
+        self._refresh_list()
+        
+        
+    def on_btn_insert_clicked(self, *args):
+        dialog = self._setup_dialog()
+        self.builder.get_object('lbl_add_remove_title').set_text(_("Insert Key Before: "))
+        self.builder.get_object('lbl_add_remove_desc').set_text(_("""Insert an item key id before the one selected.
+This means all keys with id >= that one will be incremented by 1. """))
+        resp = dialog.run()
+        dialog.hide()
+        if resp == Gtk.ResponseType.OK:
+            key = int(self.builder.get_object('id_key_add_remove').get_text())
+            tree_store: Gtk.ListStore = self.builder.get_object('tree_store')
+            new_list = []
+            for l in tree_store:
+                if l[0]>=key:
+                    new_list.append((l[2],l[0]+1))
+                else:
+                    new_list.append((l[2],l[0]))
+            new_list.sort()
+            new_list = [x[1] for x in new_list]
+            self.module.set_i2n(self._current_lang, new_list)
+            self._refresh_list()
+    def on_btn_remove_clicked(self, *args):
+        dialog = self._setup_dialog()
+        self.builder.get_object('lbl_add_remove_title').set_text(_("Remove Key: "))
+        self.builder.get_object('lbl_add_remove_desc').set_text(_("""Remove the item key id selected.
+This means all keys with id > that one will be decremented by 1.
+A key can't be removed if it's still used by one item. """))
+        resp = dialog.run()
+        dialog.hide()
+        if resp == Gtk.ResponseType.OK:
+            key = int(self.builder.get_object('id_key_add_remove').get_text())
+            tree_store: Gtk.ListStore = self.builder.get_object('tree_store')
+            no_key = []
+            for l in tree_store:
+                if key==l[0]:
+                    no_key.append(l[2])
+            if len(no_key)>0:
+                display_error(
+                    sys.exc_info(),
+                    _(f"This key is still used by these items: {', '.join(no_key)}."),
+                    _("Error removing key.")
+                )
+            else:
+                new_list = []
+                for l in tree_store:
+                    if l[0]>key:
+                        new_list.append((l[2],l[0]-1))
+                    else:
+                        new_list.append((l[2],l[0]))
+                new_list.sort()
+                new_list = [x[1] for x in new_list]
+                self.module.set_i2n(self._current_lang, new_list)
+                self._refresh_list()
+                
+    def on_id_key_add_remove_value_changed(self, widget, *args):
+        try:
+            val = int(widget.get_text())
+        except ValueError:
+            val = -1
+
+        max_key = self._get_max_key()
+        if val<0:
+            val = 0
+            widget.set_text(str(val))
+        elif val>=max_key:
+            val=max_key
+            widget.set_text(str(val))
+    def _refresh_list(self):
+        tree_store: Gtk.ListStore = self.builder.get_object('tree_store')
+        tree_store.clear()
+        lst = []
+        for i, x in enumerate(self.module.get_i2n(self._current_lang)):
+            lst.append([x, self._string_provider.get_value(StringType.ITEM_NAMES, i), i])
+        lst.sort()
+        for x in lst:
+            tree_store.append(x)
+        

--- a/skytemple/module/moves_items/module.py
+++ b/skytemple/module/moves_items/module.py
@@ -201,19 +201,19 @@ class MovesItemsModule(AbstractModule):
     def get_move(self, move_id) -> WazaMove:
         return self.get_waza_p().moves[move_id]
 
-    def get_i2n(self, lang: int) -> List[int]:
+    def get_i2n(self, in_lang: str) -> List[int]:
         sp = self.project.get_string_provider()
-        lang = sp.get_language(lang)
+        lang = sp.get_language(in_lang)
         i2n_model = self.project.open_file_in_rom(f"BALANCE/{lang.sort_lists.i2n}", ValListHandler)
         return i2n_model.get_list()
     
-    def set_i2n(self, lang: int, values: List[int]):
+    def set_i2n(self, in_lang: str, values: List[int]):
         sp = self.project.get_string_provider()
-        lang = sp.get_language(lang)
+        lang = sp.get_language(in_lang)
         i2n_model = self.project.open_file_in_rom(f"BALANCE/{lang.sort_lists.i2n}", ValListHandler)
         i2n_model.set_list(values)
         self.project.mark_as_modified(f"BALANCE/{lang.sort_lists.i2n}")
-        row = self._tree_model[self._item_keys_tree_iter]
+        row = self._tree_model[self._item_keys_tree_iter]  # type: ignore
         recursive_up_item_store_mark_as_modified(row)
 
     def mark_move_as_modified(self, move_id):

--- a/skytemple/module/moves_items/module.py
+++ b/skytemple/module/moves_items/module.py
@@ -14,7 +14,7 @@
 #
 #  You should have received a copy of the GNU General Public License
 #  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
-from typing import Dict, Tuple, Optional
+from typing import Dict, Tuple, Optional, List
 
 from gi.repository.Gtk import TreeStore, TreeIter
 
@@ -28,6 +28,7 @@ from skytemple.module.moves_items.controller.main_moves import MainMovesControll
 from skytemple.module.moves_items.controller.main_items import MainItemsController, ITEMS
 from skytemple.module.moves_items.controller.item_lists import ItemListsController
 from skytemple.module.moves_items.controller.item_effects import ItemEffectsController
+from skytemple.module.moves_items.controller.item_keys import ItemKeysController
 from skytemple.module.moves_items.controller.move import MoveController
 from skytemple.module.moves_items.controller.move_effects import MoveEffectsController
 from skytemple_files.common.types.file_types import FileType
@@ -37,6 +38,7 @@ from skytemple_files.data.item_s_p.model import ItemSP, ItemSPEntry
 from skytemple_files.data.val_list.handler import ValListHandler
 from skytemple_files.data.waza_p.model import WazaP, WazaMove
 from skytemple_files.list.items.handler import ItemListHandler
+from skytemple_files.data.val_list.handler import ValListHandler
 from skytemple_files.dungeon_data.mappa_bin.item_list import MappaItemList
 from skytemple_files.common.i18n_util import _
 
@@ -67,6 +69,7 @@ class MovesItemsModule(AbstractModule):
         self._tree_model = None
         self._item_lists_tree_iter = None
         self._item_effects_tree_iter = None
+        self._item_keys_tree_iter = None
         self._move_effects_tree_iter = None
         self.item_iters: Dict[int, TreeIter] = {}
         self.move_iters: Dict[int, TreeIter] = {}
@@ -83,6 +86,9 @@ class MovesItemsModule(AbstractModule):
         ])
         self._item_effects_tree_iter = item_store.append(root_items, [
             'skytemple-view-list-symbolic', _('Item Effects'), self, ItemEffectsController, 0, False, '', True
+        ])
+        self._item_keys_tree_iter = item_store.append(root_items, [
+            'skytemple-view-list-symbolic', _('Item Sort Keys'), self, ItemKeysController, 0, False, '', True
         ])
         self._move_effects_tree_iter = item_store.append(root_moves, [
             'skytemple-view-list-symbolic', _('Move Effects'), self, MoveEffectsController, 0, False, '', True
@@ -193,6 +199,21 @@ class MovesItemsModule(AbstractModule):
 
     def get_move(self, move_id) -> WazaMove:
         return self.get_waza_p().moves[move_id]
+
+    def get_i2n(self, lang: int) -> List[int]:
+        sp = self.project.get_string_provider()
+        lang = sp.get_language(lang)
+        i2n_model = self.project.open_file_in_rom(f"BALANCE/{lang.sort_lists.i2n}", ValListHandler)
+        return i2n_model.get_list()
+    
+    def set_i2n(self, lang: int, values: List[int]):
+        sp = self.project.get_string_provider()
+        lang = sp.get_language(lang)
+        i2n_model = self.project.open_file_in_rom(f"BALANCE/{lang.sort_lists.i2n}", ValListHandler)
+        i2n_model.set_list(values)
+        self.project.mark_as_modified(f"BALANCE/{lang.sort_lists.i2n}")
+        row = self._tree_model[self._item_keys_tree_iter]
+        recursive_up_item_store_mark_as_modified(row)
 
     def mark_move_as_modified(self, move_id):
         self.project.mark_as_modified(MOVE_FILE)


### PR DESCRIPTION
- Add an entry in General pokémon data to edit each one's idle type with the "ChangePokemonGroundAnim" patch. See Skytemple/skytemple-files#178
Import/Export should work with this value.
- Add a view to edit items sort keys under Items > Item Sort Keys.