### PR TITLE
Checks for .png file extension when exporting map bg

### DIFF
--- a/skytemple/module/map_bg/controller/bg_menu.py
+++ b/skytemple/module/map_bg/controller/bg_menu.py
@@ -544,7 +544,7 @@ class BgMenuController:
             pal = self.parent.bpl.palettes[0]
             try:
                 if is_single_mode:
-                    if '.png' not in fn:
+                    if not fn.endswith('.png'):
                         fn += '.png'
                     active_bpa.tiles_to_pil(pal).save(fn)
                 else:


### PR DESCRIPTION
simple check for '.png' extension when exporting as a single sheet and appends extension if necessary
fixes #343 