### PR TITLE
Fix dynamic library loader path variable name in Mac shell script

### DIFF
--- a/installer/build-mac.sh
+++ b/installer/build-mac.sh
@@ -48,7 +48,7 @@ cat > $appdir/pre_run_skytemple << EOF
 #!/bin/sh
 
 # Fix paths
-export LD_LIBRARY_PATH="\$(dirname \$0)"
+export DYLD_LIBRARY_PATH="\$(dirname \$0)"
 export PYENCHANT_LIBRARY_PATH="\$(dirname \$0)/libenchant-2.dylib"
 export PATH="\$PATH:\$(dirname \$0)/skytemple_files/_resources"
 


### PR DESCRIPTION
This seems to fix an issue that prevents a `libdesmume.so` built with the interface Meson script from being loaded (although it has the same name as before so maybe it was working due to PyInstaller magic in the background)