### PR TITLE
Extend DungeonInterrupt to disable music fadeout

### DIFF
--- a/skytemple/module/lists/controller/dungeon_interrupt.glade
+++ b/skytemple/module/lists/controller/dungeon_interrupt.glade
@@ -44,6 +44,8 @@
       <column type="gchararray"/>
       <!-- column-name game_var_str -->
       <column type="gchararray"/>
+      <!-- column-name continue_music -->
+      <column type="gboolean"/>
     </columns>
   </object>
   <object class="GtkListStore" id="type_store">
@@ -360,6 +362,19 @@ ASM patch from the "ASM Patches" menu.</property>
                                   </object>
                                   <attributes>
                                     <attribute name="text">4</attribute>
+                                  </attributes>
+                                </child>
+                              </object>
+                            </child>
+                            <child>
+                              <object class="GtkTreeViewColumn">
+                                <property name="title" translatable="yes">Continue Music</property>
+                                <child>
+                                  <object class="GtkCellRendererToggle" id="continue_music">
+                                    <signal name="toggled" handler="on_continue_music_toggled" swapped="no"/>
+                                  </object>
+                                  <attributes>
+                                    <attribute name="active">7</attribute>
                                   </attributes>
                                 </child>
                               </object>

--- a/skytemple/module/lists/controller/dungeon_interrupt.py
+++ b/skytemple/module/lists/controller/dungeon_interrupt.py
@@ -94,7 +94,7 @@ class DungeonInterruptController(AbstractController):
         store: Gtk.ListStore = self.builder.get_object('interrupt_store')
         store.clear()
         for p in self.inter_d.list_dungeons[self._get_current_dungeon()]:
-            store.append([p.floor,p.ent_type.value,p.game_var_id,p.param1,p.param2,p.ent_type.explanation,self.var_names[p.game_var_id]])
+            store.append([p.floor,p.ent_type.value,p.game_var_id,p.param1,p.param2,p.ent_type.explanation,self.var_names[p.game_var_id],p.continue_music])
     
     def _build_list(self):
         dungeon = self._get_current_dungeon()
@@ -110,6 +110,7 @@ class DungeonInterruptController(AbstractController):
             e.game_var_id = v[2]
             e.param1 = v[3]
             e.param2 = v[4]
+            e.continue_music = v[7]
             self.inter_d.list_dungeons[dungeon].append(e)
         
         self.module.mark_dungeon_interrupts_as_modified()
@@ -135,7 +136,7 @@ class DungeonInterruptController(AbstractController):
         
     def on_btn_add_clicked(self, *args):
         store: Gtk.ListStore = self.builder.get_object('interrupt_store')
-        store.append([0,0,0,0,0,InterDEntryType(0).explanation,self.var_names[0]])
+        store.append([0,0,0,0,0,InterDEntryType(0).explanation,self.var_names[0],0])
         self._build_list()
         
     def on_btn_remove_clicked(self, *args):
@@ -184,4 +185,8 @@ class DungeonInterruptController(AbstractController):
         except ValueError:
             return
         self._build_list()
-        
+
+    def on_continue_music_toggled(self, widget, path):
+        tree_store: Gtk.ListStore = self.builder.get_object('interrupt_store')
+        tree_store[path][7] = not widget.get_active()
+        self._build_list()


### PR DESCRIPTION
Adds an option in the UI to continue the music after exiting the floor.
See SkyTemple/skytemple-files#190.