### PR TITLE
Fix error when pressing cancel in the export portraits dialogue

### DIFF
--- a/skytemple/module/portrait/controller/portrait.py
+++ b/skytemple/module/portrait/controller/portrait.py
@@ -178,12 +178,12 @@ class PortraitController(AbstractController):
         add_dialog_png_filter(dialog)
 
         response = dialog.run()
-        fn = dialog.get_filename()
-        if '.' not in fn:
-            fn += '.png'
         dialog.destroy()
 
         if response == Gtk.ResponseType.ACCEPT:
+            fn = dialog.get_filename()
+            if '.' not in fn:
+                fn += '.png'
             SpriteBotSheet.create(self.kao, self.item_id).save(fn)
 
     def on_spritebot_import_activate(self, *args):


### PR DESCRIPTION
Originally reported in https://discord.com/channels/710190644152369162/712341752111169707/925893221643595776

This check shouldn't be done if the operation was cancelled, since `dialog.get_filename()` returns `None` in that case.