### PR TITLE
Fix off-by-two error in strings in the scenes list

### DIFF
--- a/skytemple/module/script/module.py
+++ b/skytemple/module/script/module.py
@@ -296,8 +296,8 @@ class ScriptModule(AbstractModule):
         if nameid == 0:
             return sp.get_value(StringType.GROUND_MAP_NAMES, 0), sp.get_index(StringType.GROUND_MAP_NAMES, 0)
         if nameid < 181:
-            return sp.get_value(StringType.DUNGEON_NAMES_SELECTION, nameid - 1), sp.get_index(StringType.DUNGEON_NAMES_SELECTION, nameid - 1)
-        return sp.get_value(StringType.GROUND_MAP_NAMES, nameid - 182), sp.get_index(StringType.GROUND_MAP_NAMES, nameid - 182)
+            return sp.get_value(StringType.DUNGEON_NAMES_SELECTION, nameid + 1), sp.get_index(StringType.DUNGEON_NAMES_SELECTION, nameid + 1)
+        return sp.get_value(StringType.GROUND_MAP_NAMES, nameid - 180), sp.get_index(StringType.GROUND_MAP_NAMES, nameid - 180)
 
     def get_dungeon_tilesets(self) -> List[GroundTilesetMapping]:
         config = self.project.get_rom_module().get_static_data()


### PR DESCRIPTION
Originally reported at: https://discord.com/channels/710190644152369162/712341752111169707/935004145621016576
String names and IDs shown in the "script scenes" screen are 2 places lower than they should.
For example, entry 195 should show "Wigglytuff's Guild" but instead shows "Crevice cave entrance". Some entries after, the ID of the "Wigglytuff's Guild" string is shown as #16532, when it should be #16534.

Strings start at 1, so you should add 1 to get the right string when accessing the list. Looks like you accidentally subtracted 1 instead.

I tested the change and the list now shows the right names and IDs.