### PR TITLE
Fix crash when skipping map backgrounds

### DIFF
--- a/skytemple/core/module_controller.py
+++ b/skytemple/core/module_controller.py
@@ -57,7 +57,7 @@ class AbstractController(ABC):
         if builder:
             for obj in builder.get_objects():
                 if isinstance(obj, Gtk.Window) or isinstance(obj, Gtk.Widget):
-                    obj.destroy()
+                    obj.hide()
 
     @staticmethod
     def _get_builder(pymodule_path: str, glade_file: str) -> Gtk.Builder:


### PR DESCRIPTION
Honestly, I'm not entirely sure why this works. I guess that when destroying GTK objects causes problems, it's better to just hide them instead.

Fixes #373