### PR TITLE
Make sure packaging dependency in setup.py is visible

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -76,7 +76,7 @@ setup(
         'CairoSVG >= 2.4.2',
         'gbulb >= 0.6.2',
         'psutil >= 5.8.0',
-        'sentry-sdk >= 1.5'
+        'sentry-sdk >= 1.5',
         'packaging'
     ],
     extras_require={


### PR DESCRIPTION
Not having a comma here means concatenation in Python.