### PR TITLE
Allow editing fixed room item quantities

### DIFF
--- a/skytemple/module/dungeon/controller/fixed_rooms.glade
+++ b/skytemple/module/dungeon/controller/fixed_rooms.glade
@@ -52,6 +52,8 @@
       <column type="gint"/>
       <!-- column-name item_name -->
       <column type="gchararray"/>
+      <!-- column-name item_quantity -->
+      <column type="gint"/>
     </columns>
   </object>
   <object class="GtkListStore" id="model_monsters">
@@ -856,6 +858,20 @@ They are usually used for boss fights or other special floors.</property>
                                           </object>
                                           <attributes>
                                             <attribute name="text">2</attribute>
+                                          </attributes>
+                                        </child>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkTreeViewColumn">
+                                        <property name="title" translatable="yes">Quantity</property>
+                                        <child>
+                                          <object class="GtkCellRendererText" id="cr_items_item_quantity">
+                                            <property name="editable">True</property>
+                                            <signal name="edited" handler="on_cr_items_item_quantity_edited" swapped="no"/>
+                                          </object>
+                                          <attributes>
+                                            <attribute name="text">3</attribute>
                                           </attributes>
                                         </child>
                                       </object>

--- a/skytemple/module/dungeon/controller/fixed_rooms.py
+++ b/skytemple/module/dungeon/controller/fixed_rooms.py
@@ -280,6 +280,16 @@ class FixedRoomsController(AbstractController):
         self.lst_item[int(store[path][0])].item_id = idx
         self._save()
 
+    def on_cr_items_item_quantity_edited(self, widget, path, text):
+        store: Gtk.Store = self.builder.get_object('model_items')
+        try:
+            quantity = int(text)
+        except ValueError:
+            return
+        self.lst_item[int(store[path][0])].quantity = quantity
+        store[path][3] = quantity
+        self._save()
+
     def on_cr_monsters_monster_editing_started(self, renderer, editable, path):
         editable.set_completion(self.builder.get_object('completion_monsters'))
 
@@ -469,7 +479,7 @@ class FixedRoomsController(AbstractController):
         store.clear()
         for idx, item in enumerate(self.lst_item):
             store.append([
-                str(idx), item.item_id, self.item_names[item.item_id]
+                str(idx), item.item_id, self.item_names[item.item_id], item.quantity
             ])
 
     def _init_monsters(self):


### PR DESCRIPTION
Allows edting the quantity of items placed on fixed rooms. Requires https://github.com/SkyTemple/skytemple-files/pull/226.