### PR TITLE
Fix some fixed room properties' descriptions

### DIFF
--- a/skytemple/module/dungeon/controller/fixed.glade
+++ b/skytemple/module/dungeon/controller/fixed.glade
@@ -1671,7 +1671,7 @@ if dungeon is cleared:</property>
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="halign">end</property>
-                <property name="label" translatable="yes">Prevent "Item Stealing"</property>
+                <property name="label" translatable="yes">Allow "Item Stealing"</property>
               </object>
               <packing>
                 <property name="left-attach">0</property>
@@ -1683,7 +1683,7 @@ if dungeon is cleared:</property>
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="halign">end</property>
-                <property name="label" translatable="yes">Disable all warp effects:</property>
+                <property name="label" translatable="yes">Allow warp effects:</property>
               </object>
               <packing>
                 <property name="left-attach">0</property>
@@ -1695,7 +1695,7 @@ if dungeon is cleared:</property>
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="halign">end</property>
-                <property name="label" translatable="yes">Disable some traps:</property>
+                <property name="label" translatable="yes">Allow certain traps:</property>
               </object>
               <packing>
                 <property name="left-attach">0</property>
@@ -1779,7 +1779,24 @@ Please check the help for each setting for more information.</property>
               </packing>
             </child>
             <child>
-              <placeholder/>
+              <object class="GtkButton" id="btn_help_unk5">
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="receives-default">True</property>
+                <property name="valign">center</property>
+                <signal name="clicked" handler="on_btn_help_unk5_clicked" swapped="no"/>
+                <child>
+                  <object class="GtkImage">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="icon-name">skytemple-help-about-symbolic</property>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="left-attach">2</property>
+                <property name="top-attach">6</property>
+              </packing>
             </child>
             <child>
               <placeholder/>

--- a/skytemple/module/dungeon/controller/fixed.py
+++ b/skytemple/module/dungeon/controller/fixed.py
@@ -445,11 +445,16 @@ class FixedController(AbstractController):
     def on_btn_help_defeat_enemies_clicked(self, *args):
         self._help(_("If enabled, the floor is exited after all the enemies have been defeated"))
 
+    def on_btn_help_unk5_clicked(self, *args):
+        self._help(_("If disabled, certain traps (Summon, Pitfall and Pokémon) will be disabled."
+                     "\nIf ChangeFixedFloorProperties is not applied and the fixed floor ID is 0 or >= 165 this setting is ignored. It is always enabled."))
+
     def on_btn_help_unk8_clicked(self, *args):
-        self._help(_("If ChangeFixedFloorProperties is not applied and the fixed floor ID is 0 or >= 165 this setting is ignored. It is always enabled."))
+        self._help(_("If disabled, warping, being blown away and leaping effects will be disabled."
+                     "\nIf ChangeFixedFloorProperties is not applied and the fixed floor ID is 0 or >= 165 this setting is ignored. It is always enabled."))
 
     def on_btn_help_unk9_clicked(self, *args):
-        self._help(_("Prevents any kind of item pulling (such as with the Trawl Orb)."
+        self._help(_("If disabled, prevents any kind of item pulling (such as with the Trawl Orb)."
                      "\nIf ChangeFixedFloorProperties is not applied and the fixed floor ID is 0 or >= 165 this setting is ignored. It is always enabled."))
     
     def on_btn_help_complete_clicked(self, *args):


### PR DESCRIPTION
There's three properties on the fixed room editor that have the opposite text, I've fixed them.
I also added a description for the one that disables certain traps that specifies which traps are affected by the setting.