### PR TITLE
rewrite the message for static object import

### DIFF
--- a/skytemple/module/sprite/controller/object.glade
+++ b/skytemple/module/sprite/controller/object.glade
@@ -179,9 +179,7 @@ Warning: SkyTemple does not validate the files you import.</property>
                 <property name="can-focus">False</property>
                 <property name="label" translatable="yes">You can also replace this object with a static sprite.
 It needs to have a resolution of less than 512x256px.
-It also needs to have less than 16 color, plus (optionally) a transparent "color".
-This feature hasn't been thoroughly tested, so you should check that it displays properly in-game,
-even if it is correctly displayed by the editor.</property>
+It also needs to have at most 15 color, plus (optionally) a fully transparent "color".</property>
                 <property name="justify">center</property>
               </object>
               <packing>


### PR DESCRIPTION
Just a very minor change. It also fix some potential embiguity. I didn't met any issue with this feature, nor (seemingly) others.

(ps: I'm trying to enhance my library to potentially replace the sprite import -- and will see soon on how to import simple animated object. Actually, being able to import and export object sprites as SpriteBot format is probably a good potential feature).