### PR TITLE
Add random movement chance to dungeon restrictions

### DIFF
--- a/skytemple/module/dungeon/controller/dungeon.glade
+++ b/skytemple/module/dungeon/controller/dungeon.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.38.2 -->
+<!-- Generated with glade 3.40.0 -->
 <interface>
   <requires lib="gtk+" version="3.22"/>
   <object class="GtkListStore" id="cb_direction_store">
@@ -431,7 +431,7 @@
               </packing>
             </child>
             <child>
-              <!-- n-columns=8 n-rows=4 -->
+              <!-- n-columns=10 n-rows=5 -->
               <object class="GtkGrid" id="dungeon_restrictions_grid">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
@@ -475,39 +475,6 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkSwitch" id="switch_enemies_evolve_when_team_member_koed">
-                    <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <signal name="state-set" handler="on_switch_enemies_evolve_when_team_member_koed_state_set" swapped="no"/>
-                  </object>
-                  <packing>
-                    <property name="left-attach">3</property>
-                    <property name="top-attach">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkSwitch" id="switch_enemies_grant_exp">
-                    <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <signal name="state-set" handler="on_switch_enemies_grant_exp_state_set" swapped="no"/>
-                  </object>
-                  <packing>
-                    <property name="left-attach">5</property>
-                    <property name="top-attach">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkSwitch" id="switch_recruiting_allowed">
-                    <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <signal name="state-set" handler="on_switch_recruiting_allowed_state_set" swapped="no"/>
-                  </object>
-                  <packing>
-                    <property name="left-attach">7</property>
-                    <property name="top-attach">0</property>
-                  </packing>
-                </child>
-                <child>
                   <object class="GtkSwitch" id="switch_level_reset">
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
@@ -515,53 +482,6 @@
                   </object>
                   <packing>
                     <property name="left-attach">1</property>
-                    <property name="top-attach">1</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="halign">end</property>
-                    <property name="margin-right">5</property>
-                    <property name="label" translatable="yes">Enemies evolve w. KOed:</property>
-                    <property name="justify">right</property>
-                  </object>
-                  <packing>
-                    <property name="left-attach">2</property>
-                    <property name="top-attach">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkSwitch" id="switch_money_allowed">
-                    <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <signal name="state-set" handler="on_switch_money_allowed_state_set" swapped="no"/>
-                  </object>
-                  <packing>
-                    <property name="left-attach">3</property>
-                    <property name="top-attach">1</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkSwitch" id="switch_leader_can_be_changed">
-                    <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <signal name="state-set" handler="on_switch_leader_can_be_changed_state_set" swapped="no"/>
-                  </object>
-                  <packing>
-                    <property name="left-attach">5</property>
-                    <property name="top-attach">1</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkSwitch" id="switch_dont_save_before_entering">
-                    <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <signal name="state-set" handler="on_switch_dont_save_before_entering_state_set" swapped="no"/>
-                  </object>
-                  <packing>
-                    <property name="left-attach">7</property>
                     <property name="top-attach">1</property>
                   </packing>
                 </child>
@@ -577,28 +497,6 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkSwitch" id="switch_traps_remain_invisible_on_attack">
-                    <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <signal name="state-set" handler="on_switch_traps_remain_invisible_on_attack_state_set" swapped="no"/>
-                  </object>
-                  <packing>
-                    <property name="left-attach">3</property>
-                    <property name="top-attach">2</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkSwitch" id="switch_enemies_can_drop_chests">
-                    <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <signal name="state-set" handler="on_switch_enemies_can_drop_chests_state_set" swapped="no"/>
-                  </object>
-                  <packing>
-                    <property name="left-attach">5</property>
-                    <property name="top-attach">2</property>
-                  </packing>
-                </child>
-                <child>
                   <object class="GtkEntry" id="entry_max_rescue_attempts">
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
@@ -610,74 +508,6 @@
                   <packing>
                     <property name="left-attach">1</property>
                     <property name="top-attach">3</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkEntry" id="entry_max_items_allowed">
-                    <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="valign">center</property>
-                    <property name="width-chars">3</property>
-                    <property name="max-width-chars">3</property>
-                    <signal name="changed" handler="on_entry_max_items_allowed_changed" swapped="no"/>
-                  </object>
-                  <packing>
-                    <property name="left-attach">3</property>
-                    <property name="top-attach">3</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkEntry" id="entry_max_party_members">
-                    <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="valign">center</property>
-                    <property name="width-chars">3</property>
-                    <property name="max-width-chars">3</property>
-                    <signal name="changed" handler="on_entry_max_party_members_changed" swapped="no"/>
-                  </object>
-                  <packing>
-                    <property name="left-attach">5</property>
-                    <property name="top-attach">3</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkEntry" id="entry_turn_limit">
-                    <property name="visible">True</property>
-                    <property name="can-focus">True</property>
-                    <property name="valign">center</property>
-                    <property name="width-chars">6</property>
-                    <property name="max-width-chars">6</property>
-                    <signal name="changed" handler="on_entry_turn_limit_changed" swapped="no"/>
-                  </object>
-                  <packing>
-                    <property name="left-attach">7</property>
-                    <property name="top-attach">3</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="halign">end</property>
-                    <property name="label" translatable="yes">Exp. enabled:</property>
-                    <property name="justify">right</property>
-                  </object>
-                  <packing>
-                    <property name="left-attach">4</property>
-                    <property name="top-attach">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="halign">end</property>
-                    <property name="label" translatable="yes">Recruiting enabled:</property>
-                    <property name="justify">right</property>
-                  </object>
-                  <packing>
-                    <property name="left-attach">6</property>
-                    <property name="top-attach">0</property>
                   </packing>
                 </child>
                 <child>
@@ -698,76 +528,11 @@
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
                     <property name="halign">end</property>
-                    <property name="label" translatable="yes">Money reset to 0:</property>
-                    <property name="justify">right</property>
-                  </object>
-                  <packing>
-                    <property name="left-attach">2</property>
-                    <property name="top-attach">1</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="halign">end</property>
-                    <property name="label" translatable="yes">Leader can switch:</property>
-                    <property name="justify">right</property>
-                  </object>
-                  <packing>
-                    <property name="left-attach">4</property>
-                    <property name="top-attach">1</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="halign">end</property>
-                    <property name="label" translatable="yes">Force game save:</property>
-                    <property name="justify">right</property>
-                  </object>
-                  <packing>
-                    <property name="left-attach">6</property>
-                    <property name="top-attach">1</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="halign">end</property>
                     <property name="label" translatable="yes">IQ skills enabled:</property>
                     <property name="justify">right</property>
                   </object>
                   <packing>
                     <property name="left-attach">0</property>
-                    <property name="top-attach">2</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="halign">end</property>
-                    <property name="label" translatable="yes">Reveal traps by attack:</property>
-                    <property name="justify">right</property>
-                  </object>
-                  <packing>
-                    <property name="left-attach">2</property>
-                    <property name="top-attach">2</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkLabel">
-                    <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="halign">end</property>
-                    <property name="label" translatable="yes">Enemies drop Boxes:</property>
-                    <property name="justify">right</property>
-                  </object>
-                  <packing>
-                    <property name="left-attach">4</property>
                     <property name="top-attach">2</property>
                   </packing>
                 </child>
@@ -790,24 +555,61 @@
                     <property name="visible">True</property>
                     <property name="can-focus">False</property>
                     <property name="halign">end</property>
-                    <property name="label" translatable="yes">Max. items allowed:</property>
+                    <property name="label" translatable="yes">Random movement chance:</property>
                     <property name="justify">right</property>
                   </object>
                   <packing>
-                    <property name="left-attach">2</property>
-                    <property name="top-attach">3</property>
+                    <property name="left-attach">0</property>
+                    <property name="top-attach">4</property>
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkLabel">
+                  <object class="GtkEntry" id="entry_random_movement_chance">
                     <property name="visible">True</property>
-                    <property name="can-focus">False</property>
-                    <property name="halign">end</property>
-                    <property name="label" translatable="yes">Max. party members:</property>
-                    <property name="justify">right</property>
+                    <property name="can-focus">True</property>
+                    <property name="valign">center</property>
+                    <property name="width-chars">6</property>
+                    <property name="max-width-chars">6</property>
+                    <signal name="changed" handler="on_entry_random_movement_chance_changed" swapped="no"/>
                   </object>
                   <packing>
-                    <property name="left-attach">4</property>
+                    <property name="left-attach">1</property>
+                    <property name="top-attach">4</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkSwitch" id="switch_recruiting_allowed">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <signal name="state-set" handler="on_switch_recruiting_allowed_state_set" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="left-attach">9</property>
+                    <property name="top-attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkSwitch" id="switch_dont_save_before_entering">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <signal name="state-set" handler="on_switch_dont_save_before_entering_state_set" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="left-attach">9</property>
+                    <property name="top-attach">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkEntry" id="entry_turn_limit">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="valign">center</property>
+                    <property name="width-chars">6</property>
+                    <property name="max-width-chars">6</property>
+                    <signal name="changed" handler="on_entry_turn_limit_changed" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="left-attach">9</property>
                     <property name="top-attach">3</property>
                   </packing>
                 </child>
@@ -820,9 +622,318 @@
                     <property name="justify">right</property>
                   </object>
                   <packing>
+                    <property name="left-attach">8</property>
+                    <property name="top-attach">3</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="halign">end</property>
+                    <property name="label" translatable="yes">Force game save:</property>
+                    <property name="justify">right</property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">8</property>
+                    <property name="top-attach">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="halign">end</property>
+                    <property name="label" translatable="yes">Recruiting enabled:</property>
+                    <property name="justify">right</property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">8</property>
+                    <property name="top-attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkSwitch" id="switch_enemies_grant_exp">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <signal name="state-set" handler="on_switch_enemies_grant_exp_state_set" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="left-attach">7</property>
+                    <property name="top-attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkSwitch" id="switch_leader_can_be_changed">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <signal name="state-set" handler="on_switch_leader_can_be_changed_state_set" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="left-attach">7</property>
+                    <property name="top-attach">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkSwitch" id="switch_enemies_can_drop_chests">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <signal name="state-set" handler="on_switch_enemies_can_drop_chests_state_set" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="left-attach">7</property>
+                    <property name="top-attach">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkEntry" id="entry_max_party_members">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="valign">center</property>
+                    <property name="width-chars">3</property>
+                    <property name="max-width-chars">3</property>
+                    <signal name="changed" handler="on_entry_max_party_members_changed" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="left-attach">7</property>
+                    <property name="top-attach">3</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="halign">end</property>
+                    <property name="label" translatable="yes">Max. party members:</property>
+                    <property name="justify">right</property>
+                  </object>
+                  <packing>
                     <property name="left-attach">6</property>
                     <property name="top-attach">3</property>
                   </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="halign">end</property>
+                    <property name="label" translatable="yes">Enemies drop Boxes:</property>
+                    <property name="justify">right</property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">6</property>
+                    <property name="top-attach">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="halign">end</property>
+                    <property name="label" translatable="yes">Can switch leader:</property>
+                    <property name="justify">right</property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">6</property>
+                    <property name="top-attach">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="halign">end</property>
+                    <property name="label" translatable="yes">Exp. enabled:</property>
+                    <property name="justify">right</property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">6</property>
+                    <property name="top-attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkSwitch" id="switch_enemies_evolve_when_team_member_koed">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <signal name="state-set" handler="on_switch_enemies_evolve_when_team_member_koed_state_set" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="left-attach">4</property>
+                    <property name="top-attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkSwitch" id="switch_money_allowed">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <signal name="state-set" handler="on_switch_money_allowed_state_set" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="left-attach">4</property>
+                    <property name="top-attach">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkSwitch" id="switch_traps_remain_invisible_on_attack">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <signal name="state-set" handler="on_switch_traps_remain_invisible_on_attack_state_set" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="left-attach">4</property>
+                    <property name="top-attach">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkEntry" id="entry_max_items_allowed">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="valign">center</property>
+                    <property name="width-chars">3</property>
+                    <property name="max-width-chars">3</property>
+                    <signal name="changed" handler="on_entry_max_items_allowed_changed" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="left-attach">4</property>
+                    <property name="top-attach">3</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="halign">end</property>
+                    <property name="margin-right">5</property>
+                    <property name="label" translatable="yes">Enemy evolution enabled:</property>
+                    <property name="justify">right</property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">3</property>
+                    <property name="top-attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="halign">end</property>
+                    <property name="label" translatable="yes">Money reset to 0:</property>
+                    <property name="justify">right</property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">3</property>
+                    <property name="top-attach">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="halign">end</property>
+                    <property name="label" translatable="yes">Reveal traps by attack:</property>
+                    <property name="justify">right</property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">3</property>
+                    <property name="top-attach">2</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="halign">end</property>
+                    <property name="label" translatable="yes">Max. items allowed:</property>
+                    <property name="justify">right</property>
+                  </object>
+                  <packing>
+                    <property name="left-attach">3</property>
+                    <property name="top-attach">3</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkButton" id="btn_help_random_movement_chance">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">True</property>
+                    <property name="halign">start</property>
+                    <property name="valign">center</property>
+                    <signal name="clicked" handler="on_btn_help_random_movement_chance_clicked" swapped="no"/>
+                    <child>
+                      <object class="GtkImage">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="icon-name">skytemple-help-about-symbolic</property>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="left-attach">2</property>
+                    <property name="top-attach">4</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkButton" id="btn_help_enemy_evolution">
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">True</property>
+                    <property name="halign">start</property>
+                    <property name="valign">center</property>
+                    <signal name="clicked" handler="on_btn_help_enemy_evolution_clicked" swapped="no"/>
+                    <child>
+                      <object class="GtkImage">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="icon-name">skytemple-help-about-symbolic</property>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="left-attach">5</property>
+                    <property name="top-attach">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <placeholder/>
+                </child>
+                <child>
+                  <placeholder/>
+                </child>
+                <child>
+                  <placeholder/>
+                </child>
+                <child>
+                  <placeholder/>
+                </child>
+                <child>
+                  <placeholder/>
+                </child>
+                <child>
+                  <placeholder/>
+                </child>
+                <child>
+                  <placeholder/>
+                </child>
+                <child>
+                  <placeholder/>
+                </child>
+                <child>
+                  <placeholder/>
+                </child>
+                <child>
+                  <placeholder/>
+                </child>
+                <child>
+                  <placeholder/>
+                </child>
+                <child>
+                  <placeholder/>
+                </child>
+                <child>
+                  <placeholder/>
+                </child>
+                <child>
+                  <placeholder/>
                 </child>
                 <child>
                   <placeholder/>

--- a/skytemple/module/dungeon/controller/dungeon.py
+++ b/skytemple/module/dungeon/controller/dungeon.py
@@ -21,6 +21,7 @@ from gi.repository.Gtk import ResponseType
 from range_typed_integers import i8, i8_checked, i16, i16_checked
 
 from skytemple.controller.main import MainController
+from skytemple.core.message_dialog import SkyTempleMessageDialog
 from skytemple.core.module_controller import AbstractController
 from skytemple.core.string_provider import StringType
 from skytemple.core.ui_utils import catch_overflow
@@ -119,6 +120,7 @@ class DungeonController(AbstractController):
         self.builder.get_object('entry_max_items_allowed').set_text(str(self.restrictions.max_items_allowed))
         self.builder.get_object('entry_max_party_members').set_text(str(self.restrictions.max_party_members))
         self.builder.get_object('entry_turn_limit').set_text(str(self.restrictions.turn_limit))
+        self.builder.get_object('entry_random_movement_chance').set_text(str(self.restrictions.random_movement_chance))
 
     def on_edit_floor_count_clicked(self, *args):
         dialog: Gtk.Dialog = self.builder.get_object('dialog_adjust_floor_count')
@@ -322,6 +324,28 @@ class DungeonController(AbstractController):
         self.restrictions.turn_limit = value
         self._save_dungeon_restrictions()
 
+    @catch_overflow(i16)
+    def on_entry_random_movement_chance_changed(self, w: Gtk.Entry, *args):
+        assert self.restrictions is not None
+        try:
+            value = i16_checked(int(w.get_text()))
+        except ValueError:
+            return
+        self.restrictions.random_movement_chance = value
+        self._save_dungeon_restrictions()
+
+    def on_btn_help_random_movement_chance_clicked(self, *args):
+        self._help(_("Chance of setting the random movement flag on an enemy when spawning it.\n"
+                     "Enemies with this flag set will move randomly inside rooms, instead of heading towards one of "
+                     "the exits."))
+
+    def on_btn_help_enemy_evolution_clicked(self, *args):
+        self._help(_("If enabled, enemies will evolve after defeating a team member.\n"
+                     "The evolution will not happen if the target is revived, if the evolved form of the enemy cannot "
+                     "spawn in the current floor or if the sprite of the evolved form is bigger than the sprite of "
+                     "the enemy.\n"
+                     "Part of this behavior can be modified by applying the BetterEnemyEvolution ASM patch."))
+
     # </editor-fold>
 
     def mark_as_modified(self):
@@ -340,3 +364,10 @@ class DungeonController(AbstractController):
             sp.get_model(lang).strings[
                 sp.get_index(string_type, self.dungeon_info.dungeon_id)
             ] = w.get_text().replace('\\n', '\n')
+
+    def _help(self, msg):
+        md = SkyTempleMessageDialog(MainController.window(),
+                                    Gtk.DialogFlags.DESTROY_WITH_PARENT, Gtk.MessageType.INFO,
+                                    Gtk.ButtonsType.OK, msg)
+        md.run()
+        md.destroy()

--- a/skytemple/module/dungeon/controller/floor.glade
+++ b/skytemple/module/dungeon/controller/floor.glade
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Generated with glade 3.38.2 -->
+<!-- Generated with glade 3.40.0 -->
 <interface>
   <requires lib="gtk+" version="3.22"/>
   <object class="GtkAdjustment" id="adjustment1">


### PR DESCRIPTION
Adds the recently documented "random movement chance" value to the dungeon restrictions screen.
I also added a help button for it and for the "enemy evolution enabled" flag, so the layout got reorganized a bit.

See also [the skytemple-files PR](https://github.com/SkyTemple/skytemple-files/pull/333).