### PR TITLE
Sentry: Add session tracking

### DIFF
--- a/skytemple/core/logger.py
+++ b/skytemple/core/logger.py
@@ -43,6 +43,23 @@ logger = logging.getLogger('system')
 SKYTEMPLE_LOGLEVEL = os.environ.get("SKYTEMPLE_LOGLEVEL", logging.getLevelName(default_loglevel()))
 
 
+def current_log_level():
+    """Same as SKYTEMPLE_LOGLEVEL, but the numeric value."""
+    if sys.version_info >= (3, 11):
+        return logging.getLevelNamesMapping()[SKYTEMPLE_LOGLEVEL]
+    _nameToLevel = {
+        'CRITICAL': logging.CRITICAL,
+        'FATAL': logging.FATAL,
+        'ERROR': logging.ERROR,
+        'WARN': logging.WARNING,
+        'WARNING': logging.WARNING,
+        'INFO': logging.INFO,
+        'DEBUG': logging.DEBUG,
+        'NOTSET': logging.NOTSET,
+    }
+    return _nameToLevel[SKYTEMPLE_LOGLEVEL]
+
+
 def async_handle_exeception(loop: AbstractEventLoop, context):
     """Exception handler for asyncio-like event loops"""
     if "exception" in context:

--- a/skytemple/core/logger.py
+++ b/skytemple/core/logger.py
@@ -29,7 +29,18 @@ from skytemple.core.error_handler import display_error
 from skytemple_files.common.project_file_manager import ProjectFileManager
 from skytemple_files.common.i18n_util import _, f
 
+from skytemple.core.ui_utils import version
+
+
+def default_loglevel():
+    if version() == 'dev':
+        return logging.DEBUG
+    else:
+        return logging.INFO
+
+
 logger = logging.getLogger('system')
+SKYTEMPLE_LOGLEVEL = os.environ.get("SKYTEMPLE_LOGLEVEL", logging.getLevelName(default_loglevel()))
 
 
 def async_handle_exeception(loop: AbstractEventLoop, context):
@@ -75,3 +86,4 @@ def setup_logging():
         format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',
         handlers=[logging.StreamHandler(), handler]
     )
+    logging.getLogger().setLevel(SKYTEMPLE_LOGLEVEL)

--- a/skytemple/core/sentry.py
+++ b/skytemple/core/sentry.py
@@ -28,7 +28,7 @@ from sentry_sdk.integrations.logging import LoggingIntegration
 from sentry_sdk.sessions import auto_session_tracking
 from sentry_sdk.utils import logger as sentry_sdk_logger
 
-from skytemple.core.logger import SKYTEMPLE_LOGLEVEL
+from skytemple.core.logger import SKYTEMPLE_LOGLEVEL, current_log_level
 from skytemple.core.ui_utils import version
 
 if TYPE_CHECKING:
@@ -83,7 +83,7 @@ def init():
             sentry_sdk_logger.setLevel(SKYTEMPLE_LOGLEVEL)
             logger.setLevel(SKYTEMPLE_LOGLEVEL)
             sentry_logging = LoggingIntegration(
-                level=logging.getLevelNamesMapping()[SKYTEMPLE_LOGLEVEL],  # Capture as breadcrumbs
+                level=current_log_level(),  # Capture as breadcrumbs
                 event_level=None  # Send no errors as events
             )
             sentry_sdk.init(

--- a/skytemple/main.py
+++ b/skytemple/main.py
@@ -140,7 +140,8 @@ from skytemple_files.common.i18n_util import _
 
 gi.require_version('Gtk', '3.0')
 
-from skytemple.core.logger import setup_logging
+from skytemple.core.logger import setup_logging, SKYTEMPLE_LOGLEVEL
+
 setup_logging()
 
 from skytemple.core.message_dialog import SkyTempleMessageDialog
@@ -167,8 +168,6 @@ except ImportError:
 from gi.repository import Gtk, Gdk, GLib
 from gi.repository.Gtk import Window
 from skytemple.controller.main import MainController
-
-SKYTEMPLE_LOGLEVEL = os.environ.get("SKYTEMPLE_LOGLEVEL", logging.getLevelName(logging.INFO))
 
 
 def run_main(settings: SkyTempleSettingsStore):
@@ -251,8 +250,6 @@ def _load_theme(settings: SkyTempleSettingsStore):
 
 def main():
     # TODO: At the moment doesn't support any cli arguments.
-    logging.basicConfig()
-    logging.getLogger().setLevel(SKYTEMPLE_LOGLEVEL)
     from skytemple.core.async_tasks.delegator import AsyncTaskDelegator
     AsyncTaskDelegator.run_main(run_main, settings)
 


### PR DESCRIPTION
This gives me the ability to see how much new versions of SkyTemple are adopted.
![image](https://github.com/SkyTemple/skytemple/assets/3512122/7e798674-3102-4af5-873c-4c2196ceebc4)

You can see that for the dev release at the top it now shows adoption data, where previously no data was available.

This PR also fixes some logging related issues.
