### PR TITLE
Small change to window size and maximized handling

### DIFF
--- a/skytemple/controller/main.py
+++ b/skytemple/controller/main.py
@@ -299,8 +299,9 @@ class MainController:
 
     def on_main_window_configure_event__handle(self):
         self.settings.set_window_position(self._window.get_position())
-        self.settings.set_window_size(self._window.get_size())
         self.settings.set_window_maximized(self._window.is_maximized())
+        if not self._window.is_maximised():
+            self.settings.set_window_size(self._window.get_size()) 
         self._resize_timeout_id = None
 
     def on_main_window_state_event(self, w: Gtk.Window, evt: Gdk.EventWindowState):


### PR DESCRIPTION
Previously the screen size would be saved to the settings when maximized, causing the program to forget the previous screen size and take up the whole screen when unmaximized.

This change fixes that by only storing the window size if it is not maximized which should return the window to its original size before it was maximized. Will need checking as my ST development installation is broken and I can't figure out how to fix it.