### PR TITLE
Add native ARM macOS build

### DIFF
--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -211,7 +211,7 @@ jobs:
             installer/skytemple-*-install-*.exe
 
   package-mac:
-    runs-on: macos-11
+    runs-on: macos-12
     name: Build and package for Mac OS (Intel)
     steps:
       - name: Checkout
@@ -342,11 +342,7 @@ jobs:
           chmod +x armips
 
           # Package
-          if [ "$(uname -m)" = "arm64" ]; then
-            ./build-mac-arm.sh $PACKAGE_VERSION
-          else
-            ./build-mac.sh $PACKAGE_VERSION
-          fi
+          ./build-mac-arm.sh $PACKAGE_VERSION
 
           # Creating a zip makes the artifact upload much faster since there are so many files
           zip -r skytemple-mac.zip dist/SkyTemple.app > /dev/null

--- a/.github/workflows/build-test-publish.yml
+++ b/.github/workflows/build-test-publish.yml
@@ -212,7 +212,7 @@ jobs:
 
   package-mac:
     runs-on: macos-11
-    name: Build and package for Mac OS
+    name: Build and package for Mac OS (Intel)
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -269,7 +269,7 @@ jobs:
       - name: Upload .app
         uses: actions/upload-artifact@v3
         with:
-          name: skytemple-mac-app
+          name: skytemple-mac-app-x86_64
           path: |
             installer/skytemple-mac.zip
 
@@ -288,7 +288,92 @@ jobs:
       - name: Upload .dmg
         uses: actions/upload-artifact@v3
         with:
-          name: skytemple-mac-dmg
+          name: skytemple-mac-dmg-x86_64
+          path: |
+            installer/SkyTemple*.dmg
+  
+  package-mac-arm64:
+    runs-on: macos-14
+    name: Build and package for Mac OS (ARM)
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Rewrite version for dev if not tag
+        if: "!startsWith(github.ref, 'refs/tags/')"
+        run: |
+          perl -i -pe "s/version\s*=\s*\"(.*?)(\.rc.*|\.a.*|\.post.*)?\"/version=\"\1.dev0+${GITHUB_SHA::8}\"/" pyproject.toml
+          echo "IS_DEV_BUILD=1" >> $GITHUB_ENV
+      - name: Note version
+        run: |
+          python3 -m venv .yq-venv
+          . .yq-venv/bin/activate
+          pip install yq
+          echo "PACKAGE_VERSION=$(tomlq '.project.version' pyproject.toml -r)" >> $GITHUB_ENV
+      - name: Install and package
+        run: |
+          # git is already installed.
+          brew install enchant pygobject3 gtk+3 python@3.11 gtksourceview4 adwaita-icon-theme sdl12-compat sdl2 meson cmake
+          pip3 install -U certifi
+          export PATH=/usr/local/opt/python@3.11/bin:/usr/local/bin:/opt/homebrew/bin:$PATH
+
+          # Install other dependencies and SkyTemple itself
+          pip3 install py-desmume 'pyinstaller~=5.0'
+          if [ -n "$IS_DEV_BUILD" ]; then
+            IS_MACOS=1 installer/install-skytemple-rust.sh x86_64
+          fi
+          pip3 install -r requirements-mac-windows.txt
+          # Generate MO localization files
+          installer/generate-mo.sh
+          pip3 install '.[eventserver]'
+          if [ -n "$IS_DEV_BUILD" ]; then
+            installer/install-skytemple-components-from-git.sh
+          fi
+
+          cd installer
+
+          # Install themes
+          curl https://skytemple.org/build_deps/Arc.zip -O
+          unzip Arc.zip > /dev/null
+          curl https://skytemple.org/build_deps/ZorinBlue.zip -O
+          unzip ZorinBlue.zip > /dev/null
+
+          # Download armips
+          curl https://skytemple.org/build_deps/mac/armips -O
+          chmod +x armips
+
+          # Package
+          if [ "$(uname -m)" = "arm64" ]; then
+            ./build-mac-arm.sh $PACKAGE_VERSION
+          else
+            ./build-mac.sh $PACKAGE_VERSION
+          fi
+
+          # Creating a zip makes the artifact upload much faster since there are so many files
+          zip -r skytemple-mac.zip dist/SkyTemple.app > /dev/null
+
+      - name: Upload .app
+        uses: actions/upload-artifact@v3
+        with:
+          name: skytemple-mac-app-arm64
+          path: |
+            installer/skytemple-mac.zip
+
+      - name: Create installer
+        run: |
+          export PATH=/usr/local/opt/python@3.11/bin:/usr/local/bin:/opt/homebrew/bin:$PATH
+          
+          # See https://github.com/sindresorhus/create-dmg
+          # create-dmg automatically generates an installer icon if imagemagick is installed
+          brew install graphicsmagick imagemagick
+          npm -g install create-dmg
+
+          # This tool returns exit code 2 if the DMG was created but code signing failed for some reason
+          npx create-dmg --dmg-title=SkyTemple installer/dist/SkyTemple.app installer || true
+
+      - name: Upload .dmg
+        uses: actions/upload-artifact@v3
+        with:
+          name: skytemple-mac-dmg-arm64
           path: |
             installer/SkyTemple*.dmg
 

--- a/installer/install-skytemple-rust.sh
+++ b/installer/install-skytemple-rust.sh
@@ -8,7 +8,12 @@ branch="master"
 wheel_name="skytemple_rust-*-cp311-cp311-win_amd64.whl"
 
 if [ -n "$IS_MACOS" ]; then
-  wheel_name="skytemple_rust-*-cp311-cp311-macosx_10_9_x86_64.whl"
+  # Check if we're running on Apple Silicon
+  if [ "$(uname -m)" = "arm64" ]; then
+    wheel_name="skytemple_rust-*-cp311-cp311-macosx_11_0_arm64.whl"
+  else
+    wheel_name="skytemple_rust-*-cp311-cp311-macosx_10_9_x86_64.whl"
+  fi
 fi
 
 url="https://nightly.link/SkyTemple/skytemple-rust/workflows/build-test-publish/$branch/wheels.zip"

--- a/installer/skytemple-mac.spec
+++ b/installer/skytemple-mac.spec
@@ -8,6 +8,11 @@ from PyInstaller.utils.hooks import collect_entry_point, copy_metadata
 pkg_path = os.path.abspath(os.path.join("..", "skytemple"))
 site_packages = next(p for p in sys.path if "site-packages" in p)
 
+# The Homebrew lib path is different on ARM and Intel
+homebrew_path = os.path.join(os.sep, "usr", "local")
+if os.uname().machine == "arm64":
+    homebrew_path = os.path.join(os.sep, "opt", "homebrew")
+
 additional_datas = [
     (os.path.join(pkg_path, "data"), "data"),
     (os.path.join(pkg_path, "*.glade"), "."),
@@ -72,29 +77,29 @@ additional_datas = [
 additional_binaries = [
     (os.path.join(site_packages, "desmume", "libdesmume.dylib"), "."),
     (
-        os.path.join(os.sep, "usr", "local", "lib", "libSDL-1.2.0.dylib"),
+        os.path.join(homebrew_path, "lib", "libSDL-1.2.0.dylib"),
         ".",
     ),  # Must be installed with Homebrew
     (
-        os.path.join(os.sep, "usr", "local", "lib", "libSDL2-2.0.0.dylib"),
+        os.path.join(homebrew_path, "lib", "libSDL2-2.0.0.dylib"),
         ".",
     ),  # Must be installed with Homebrew
     (
-        os.path.join(os.sep, "usr", "local", "lib", "libenchant-2.dylib"),
+        os.path.join(homebrew_path, "lib", "libenchant-2.dylib"),
         ".",
     ),  # Must be installed with Homebrew
     (
-        os.path.join(os.sep, "usr", "local", "lib", "libaspell.15.dylib"),
+        os.path.join(homebrew_path, "lib", "libaspell.15.dylib"),
         ".",
     ),  # Gets installed with Enchant
     (
         os.path.join(
-            os.sep, "usr", "local", "lib", "enchant-2", "enchant_applespell.so"
+            homebrew_path, "lib", "enchant-2", "enchant_applespell.so"
         ),
         ".",
     ),  # Gets installed with Enchant
     (
-        os.path.join(os.sep, "usr", "local", "opt", "cairo", "lib", "libcairo.2.dylib"),
+        os.path.join(homebrew_path, "opt", "cairo", "lib", "libcairo.2.dylib"),
         ".",
     ),
     (os.path.join(site_packages, "libtilequant.dylib"), "."),

--- a/skytemple/main.py
+++ b/skytemple/main.py
@@ -30,14 +30,14 @@ from skytemple_files.common.impl_cfg import (
 # Workaround for errors on macOS when running from a bundle
 if sys.platform.startswith("darwin"):
     base_path = Path(__file__).parent.absolute().as_posix()
-    os.chdir(base_path) # Set working directory to the executable directory
+    os.chdir(base_path)  # Set working directory to the executable directory
     os.environ["DYLD_LIBRARY_PATH"] = base_path
     os.environ["PATH"] = f"{base_path}/skytemple_files/_resources:{os.environ['PATH']}"
     os.environ["PYENCHANT_LIBRARY_PATH"] = f"{base_path}/libenchant-2.dylib"
 
     # Disable SDL video. It's not used and would only be required with joystick/gamepad support,
     # but alas it doesn't work because Cococa only supports I/O from the main thread.
-    os.environ["SDL_VIDEODRIVER"] = "dummy" # Fixes the debugger not loading
+    os.environ["SDL_VIDEODRIVER"] = "dummy"  # Fixes the debugger not loading
 
 settings = SkyTempleSettingsStore()
 

--- a/skytemple/main.py
+++ b/skytemple/main.py
@@ -19,12 +19,25 @@ import os
 import sys
 import locale
 import gettext
+from pathlib import Path
 from skytemple.core.ui_utils import data_dir, APP, builder_get_assert
 from skytemple.core.settings import SkyTempleSettingsStore
 from skytemple_files.common.impl_cfg import (
     ENV_SKYTEMPLE_USE_NATIVE,
     change_implementation_type,
 )
+
+# Workaround for errors on macOS when running from a bundle
+if sys.platform.startswith("darwin"):
+    base_path = Path(__file__).parent.absolute().as_posix()
+    os.chdir(base_path) # Set working directory to the executable directory
+    os.environ["DYLD_LIBRARY_PATH"] = base_path
+    os.environ["PATH"] = f"{base_path}/skytemple_files/_resources:{os.environ['PATH']}"
+    os.environ["PYENCHANT_LIBRARY_PATH"] = f"{base_path}/libenchant-2.dylib"
+
+    # Disable SDL video. It's not used and would only be required with joystick/gamepad support,
+    # but alas it doesn't work because Cococa only supports I/O from the main thread.
+    os.environ["SDL_VIDEODRIVER"] = "dummy" # Fixes the debugger not loading
 
 settings = SkyTempleSettingsStore()
 


### PR DESCRIPTION
Adds a new GitHub Actions job to generate native binaries for ARM Macs using the new `macos-14` runner.

The most annoying difference is that all app bundles must be signed to run on Apple Silicon Macs (self-signed certificates are fine). PyInstaller already takes care of signing, but macOS refuses to load app bundles that were tampered with. Thus, we can't copy shell scripts or other files into the bundle after its creation anymore (I tried re-signing it, but I couldn't get it to work). The easiest workaround to get things running was adding code to setup environment variables in `main.py` instead, so that's what I did. I didn't include code from the wrapper script that reads the system language because SkyTemple seems to detect the language without it.

I didn't test every single feature (consider this a "beta version"), but the general UI and debugger seemed to work fine. The only issue I've noticed is an error while loading the spellchecker (which might also be present in the Intel version because barely anyone uses this feature):
```
2024-01-31 17:35:49,637 - skytemple_ssb_debugger.controller.script_editor - ERROR - Failed toggling/loading spellchecker:
Traceback (most recent call last):
  File "skytemple_ssb_debugger/controller/script_editor.py", line 709, in toggle_spellchecker
  File "gtkspellcheck/spellcheck.py", line 307, in __init__
gtkspellcheck.spellcheck.NoDictionariesFound
```