### PR TITLE
Fix issue with strings export

### DIFF
--- a/skytemple/module/strings/widget/strings.py
+++ b/skytemple/module/strings/widget/strings.py
@@ -221,7 +221,7 @@ class StStringsStringsPage(Gtk.Box):
             fn = add_extension_if_missing(fn, "csv")
             with open_utf8(fn, "w", newline="") as result_file:
                 wr = csv.writer(result_file, lineterminator="\n")
-                wr.writerows([[x] for x in self._str.strings])
+                wr.writerows([[x.replace('\n', '\\n')] for x in self._str.strings])
 
     def _visibility_func(self, model, iter, *args):
         if self._active_category is not None:


### PR DESCRIPTION
Small fix to string export mechanism - this ensures that strings which contain new lines aren't being written as actual new lines, which violates the "contains all strings in order, one per row" specification.

Comparison:
[old-str-export.csv](https://github.com/SkyTemple/skytemple/files/14952951/old-str-export.csv)
[new-str-export.csv](https://github.com/SkyTemple/skytemple/files/14952950/new-str-export.csv)
