### PR TITLE
Fix incorrect error message

### DIFF
--- a/skytemple/module/patch/widget/asm.py
+++ b/skytemple/module/patch/widget/asm.py
@@ -354,7 +354,7 @@ class StPatchAsmPage(Gtk.Box):
                         (
                             f(
                                 _(
-                                    "Error loading patch package {os.path.basename(fname)}."
+                                    "Error loading patch package {patch.name}."
                                 )
                             ),
                             sys.exc_info(),

--- a/skytemple/module/patch/widget/asm.py
+++ b/skytemple/module/patch/widget/asm.py
@@ -352,11 +352,7 @@ class StPatchAsmPage(Gtk.Box):
                 except BaseException:
                     errors.append(
                         (
-                            f(
-                                _(
-                                    "Error loading patch package {patch.name}."
-                                )
-                            ),
+                            f(_("Error loading patch package {patch.name}.")),
                             sys.exc_info(),
                         )
                     )


### PR DESCRIPTION
The wrong patch name would be shown in the error message when a custom ASM patch fails to load.