### PR TITLE
Fix typo when importing portraits

### DIFF
--- a/skytemple/data/locale/cs_CZ/LC_MESSAGES/skytemple.po
+++ b/skytemple/data/locale/cs_CZ/LC_MESSAGES/skytemple.po
@@ -9548,7 +9548,7 @@ msgstr ""
 
 #: skytemple/skytemple/module/portrait/controller/portrait.py:135
 msgid "To import, select a directory to import from. Files with the pattern '{self.item_id + 1}_XX.png'\n"
-"will be imported, where XX is a number between 0 and 40."
+"will be imported, where XX is a number between 0 and 39."
 msgstr ""
 
 #: skytemple/skytemple/module/portrait/controller/portrait.py:137

--- a/skytemple/module/portrait/widget/portrait.py
+++ b/skytemple/module/portrait/widget/portrait.py
@@ -301,7 +301,7 @@ class StPortraitPortraitPage(Gtk.Box):
             Gtk.ButtonsType.OK,
             f(
                 _(
-                    "To import, select a directory to import from. Files with the pattern '{self.item_data + 1}_XX.png'\nwill be imported, where XX is a number between 0 and 40."
+                    "To import, select a directory to import from. Files with the pattern '{self.item_data + 1}_XX.png'\nwill be imported, where XX is a number between 0 and 39."
                 )
             ),
             title=_("Import Portraits"),


### PR DESCRIPTION
When importing portraits from multiple files, the information popup incorrect states that XX ranges from 0-40, which would mean a range of 41, when in reality, a mon can only have 40 portraits. This has been remedied to state a range of 0-39 for a total of 40 portraits.