### PR TITLE
Support raw exceptions in error display code, remove cgitb

### DIFF
--- a/skytemple/core/error_handler.py
+++ b/skytemple/core/error_handler.py
@@ -63,6 +63,7 @@ def show_error_web(exc_info):
             html = cgitb.text(exc_info)
             with NamedTemporaryFile(delete=False, mode="w", suffix=".txt") as tmp_file2:
                 tmp_file2.write(html)
+                tmp_file2.flush()
                 webbrowser.open_new_tab(Path(tmp_file2.name).as_uri())
         except BaseException:
             # Hm... now it's getting ridiculous.
@@ -70,6 +71,7 @@ def show_error_web(exc_info):
                 html = "".join(traceback.format_exception(*exc_info))
                 with NamedTemporaryFile(delete=False, mode="w", suffix=".txt") as tmp_file3:
                     tmp_file3.write(html)
+                    tmp_file3.flush()
                     webbrowser.open_new_tab(Path(tmp_file3.name).as_uri())
             except BaseException:
                 # Yikes!
@@ -109,6 +111,9 @@ def display_error(
     """
     :param should_report: Whether or not the error should be reported. UserValueErrors are never to be reported.
     """
+    if isinstance(exc_info, Exception):
+        exc_info = (type(exc_info), exc_info, exc_info.__traceback__)
+
     if error_title is None:
         error_title = _("SkyTemple - Error!")
     # In case the current working directory is corrupted. Yes, this may happen.

--- a/skytemple/core/error_handler.py
+++ b/skytemple/core/error_handler.py
@@ -16,7 +16,6 @@
 #
 #  You should have received a copy of the GNU General Public License
 #  along with SkyTemple.  If not, see <https://www.gnu.org/licenses/>.
-import cgitb
 import logging
 import os
 import traceback
@@ -29,6 +28,7 @@ from typing import Union, Any, Optional, cast
 from skytemple_files.common.util import Capturable
 from skytemple_files.user_error import USER_ERROR_MARK
 
+from skytemple.core.ui_utils import version
 from skytemple.core.widget.user_feedback import StUserFeedbackWindow
 
 try:
@@ -49,53 +49,26 @@ ExceptionInfo = Union[BaseException, tuple[type[BaseException], BaseException, T
 
 
 def show_error_web(exc_info):
-    tmp_file1 = None
-    tmp_file2 = None
-    tmp_file3 = None
     try:
-        html = cgitb.html(exc_info)
-        with NamedTemporaryFile(delete=False, mode="w", suffix=".html") as tmp_file1:
-            tmp_file1.write(html)
-            webbrowser.open_new_tab(Path(tmp_file1.name).as_uri())
+        text = f"SkyTemple {version()} Error Report\n\n"
+        text += "".join(traceback.format_exception(*exc_info))
+        with NamedTemporaryFile(delete=False, mode="w", suffix=".txt") as tmp_file:
+            tmp_file.write(text)
+            tmp_file.flush()
+            webbrowser.open_new_tab(Path(tmp_file.name).as_uri())
     except BaseException:
-        # Oof. This happens sometimes with some exceptions ("AttributeError: characters_written").
-        try:
-            html = cgitb.text(exc_info)
-            with NamedTemporaryFile(delete=False, mode="w", suffix=".txt") as tmp_file2:
-                tmp_file2.write(html)
-                tmp_file2.flush()
-                webbrowser.open_new_tab(Path(tmp_file2.name).as_uri())
-        except BaseException:
-            # Hm... now it's getting ridiculous.
-            try:
-                html = "".join(traceback.format_exception(*exc_info))
-                with NamedTemporaryFile(delete=False, mode="w", suffix=".txt") as tmp_file3:
-                    tmp_file3.write(html)
-                    tmp_file3.flush()
-                    webbrowser.open_new_tab(Path(tmp_file3.name).as_uri())
-            except BaseException:
-                # Yikes!
-                md = SkyTempleMessageDialog(
-                    None,
-                    Gtk.DialogFlags.DESTROY_WITH_PARENT,
-                    Gtk.MessageType.ERROR,
-                    Gtk.ButtonsType.OK,
-                    (
-                        _("Trying to display the error failed. Wow!")
-                        + "\n"
-                        + _("You can try opening one of the following file manually in a web browser or text editor: ")
-                        + "\n - "
-                        + (tmp_file1.name if tmp_file1 is not None else "")
-                        + "\n - "
-                        + (tmp_file2.name if tmp_file2 is not None else "")
-                        + "\n - "
-                        + (tmp_file3.name if tmp_file3 is not None else "")
-                    ),
-                    title=":(",
-                    text_selectable=True,
-                )
-                md.run()
-                md.destroy()
+        # Yikes!
+        md = SkyTempleMessageDialog(
+            None,
+            Gtk.DialogFlags.DESTROY_WITH_PARENT,
+            Gtk.MessageType.ERROR,
+            Gtk.ButtonsType.OK,
+            _("Trying to display the error failed. Wow!"),
+            title=":(",
+            text_selectable=True,
+        )
+        md.run()
+        md.destroy()
 
 
 def display_error(


### PR DESCRIPTION
The SpriteCollab browser was just passing a normal exception, not an `exc_info` tuple, to the `display_error` function. This updates the code so that this is now supported. `cgitb` still errors out but the fallbacks work, so it's "good enough".

This also removes usage of `cgitb`, since that will be removed in Python 3.13