### PR TITLE
Fix linebreaks when importing strings

### DIFF
--- a/skytemple/module/strings/widget/strings.py
+++ b/skytemple/module/strings/widget/strings.py
@@ -168,7 +168,7 @@ class StStringsStringsPage(Gtk.Box):
                     strings = []
                     for row in csv_reader:
                         if len(row) > 0:
-                            strings.append(row[0])
+                            strings.append(row[0].replace("\\n", "\n"))
                     if len(self._str.strings) != len(strings):
                         raise ValueError(
                             f(


### PR DESCRIPTION
Fixes #812. When exporting strings to a CSV, actual linebreaks are swapped for `\n`, as shown here:
```
wr.writerows([[x.replace("\n", "\\n")] for x in self._str.strings])
```
The issue arises from the fact that this is not undone when importing, meaning the linebreaks stay as `\n` instead of actual linebreaks. This can be undone by adding a `replace("\\n", "\n")` to the code relevant to importing, causing the new code to look like this:
```
strings.append(row[0].replace("\\n", "\n"))
```
This should cause linebreaks to be imported properly instead of as `\n`.

I'm unable to build SkyTemple to see if this works myself, but I'm hoping my logic makes sense.